### PR TITLE
tests use in-memory transport 

### DIFF
--- a/sdk/requirements.txt
+++ b/sdk/requirements.txt
@@ -1,2 +1,4 @@
 faststream[kafka]==0.5.40
 pydantic==2.11.4
+pytest==8.3.5
+pytest-asyncio==1.0.0

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from eggai.transport.inmemory import InMemoryTransport
+
+@pytest.fixture(autouse=True)
+def reset_inmemory_transport():
+    InMemoryTransport._CHANNELS.clear()
+    InMemoryTransport._SUBSCRIPTIONS.clear()
+    yield
+    InMemoryTransport._CHANNELS.clear()
+    InMemoryTransport._SUBSCRIPTIONS.clear()

--- a/sdk/tests/test_catch_all.py
+++ b/sdk/tests/test_catch_all.py
@@ -4,9 +4,11 @@ from collections import defaultdict
 import pytest
 
 from eggai import Agent, Channel
-from eggai.transport import KafkaTransport, eggai_set_default_transport
+from eggai.transport import InMemoryTransport, eggai_set_default_transport
 
-eggai_set_default_transport(lambda: KafkaTransport())
+# Use the lightweight in-memory transport for tests to avoid requiring a
+# running Kafka broker.
+eggai_set_default_transport(lambda: InMemoryTransport())
 
 hits = defaultdict(int)
 
@@ -32,6 +34,7 @@ async def test_catch_all(capfd):
     })
     await asyncio.sleep(0.5)
     await agent.stop()
+    await channel.stop()
     assert hits["msg1"] == 1
     # check no SubscriberNotFound exception is raised in the output of the test run
     captured = capfd.readouterr()

--- a/sdk/tests/test_kafka.py
+++ b/sdk/tests/test_kafka.py
@@ -3,9 +3,9 @@ import asyncio
 import pytest
 
 from eggai import Agent, Channel
-from eggai.transport import KafkaTransport, eggai_set_default_transport
+from eggai.transport import InMemoryTransport, eggai_set_default_transport
 
-eggai_set_default_transport(lambda: KafkaTransport())
+eggai_set_default_transport(lambda: InMemoryTransport())
 
 hits = {}
 
@@ -37,6 +37,9 @@ async def test_kafka(capfd):
     assert hits.get("order_requested") == 1
     assert hits.get("order_created") == 1
 
+    await agent.stop()
+    await default_channel.stop()
+
 
 @pytest.mark.asyncio
 async def test_channel_subscribe_multiple():
@@ -62,3 +65,7 @@ async def test_channel_subscribe_multiple():
     assert len(received_other_channel) == 1, (
         f"Expected 1 event for 'other_channel', got {len(received_other_channel)}"
     )
+
+    await channel1.stop()
+    await channel2.stop()
+    await other_channel.stop()

--- a/sdk/tests/test_simple_scenario.py
+++ b/sdk/tests/test_simple_scenario.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 from eggai import Agent, Channel
-from eggai.transport import eggai_set_default_transport, KafkaTransport
+from eggai.transport import eggai_set_default_transport, InMemoryTransport
 
 agent = Agent("OrderAgent")
 channel = Channel()
@@ -28,7 +28,7 @@ async def handle_order_created(event):
 
 @pytest.mark.asyncio
 async def test_simple_scenario(capfd):
-    eggai_set_default_transport(lambda: KafkaTransport())
+    eggai_set_default_transport(lambda: InMemoryTransport())
 
     await agent.start()
     await channel.publish({
@@ -41,3 +41,4 @@ async def test_simple_scenario(capfd):
     assert hits.get("msg1") == 2
     assert hits.get("msg2") == 2
     await agent.stop()
+    await channel.stop()


### PR DESCRIPTION
## Summary
- tests use in-memory transport from previous work

## Testing
- `pytest sdk/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68594a008f5083289fd14131dc547e9b