### PR TITLE
Move policy scripts under example

### DIFF
--- a/examples/multi_agent_human_chat/Dockerfile
+++ b/examples/multi_agent_human_chat/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 COPY agents /app/agents
 COPY libraries /app/libraries
+COPY scripts /app/scripts
 
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r /app/requirements.txt

--- a/examples/multi_agent_human_chat/Makefile
+++ b/examples/multi_agent_human_chat/Makefile
@@ -208,7 +208,7 @@ start-escalation:
 
 start-policies:
 	@echo "Starting Policies Agent..."
-	@source $(VENV_DIR)/bin/activate && $(VENV_DIR)/bin/python -m agents.policies.agent.main
+	@source $(VENV_DIR)/bin/activate && $(VENV_DIR)/bin/python -m scripts.start_policies
 
 start-policies-document-ingestion:
 	@echo "Starting Policies Document Ingestion Service..."

--- a/examples/multi_agent_human_chat/agents/policies/tests/retrieval_performance/api_client.py
+++ b/examples/multi_agent_human_chat/agents/policies/tests/retrieval_performance/api_client.py
@@ -81,7 +81,7 @@ class RetrievalAPIClient:
                 return False
 
             process = subprocess.Popen(
-                [sys.executable, "-m", "agents.policies.agent.main"],
+                [sys.executable, "-m", "scripts.start_policies"],
                 cwd=str(project_root),
             )
 

--- a/examples/multi_agent_human_chat/helm/templates/deployments.yaml
+++ b/examples/multi_agent_human_chat/helm/templates/deployments.yaml
@@ -427,7 +427,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           args:
-          - agents.policies.agent.main
+          - scripts.start_policies
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/examples/multi_agent_human_chat/scripts/start_policies.py
+++ b/examples/multi_agent_human_chat/scripts/start_policies.py
@@ -1,0 +1,12 @@
+"""Convenience entry point to run the Policies Agent."""
+
+import uvicorn
+
+
+def main() -> None:
+    """Launch the Policies Agent API using Uvicorn."""
+    uvicorn.run("agents.policies.agent.main:api", host="0.0.0.0", port=8002)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_agent_human_chat/scripts/test_audit_agent.py
+++ b/examples/multi_agent_human_chat/scripts/test_audit_agent.py
@@ -1,0 +1,15 @@
+"""Run tests for the Audit Agent."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    test_path = repo_root / "agents" / "audit"
+    subprocess.run([sys.executable, "-m", "pytest", str(test_path), "-s"], check=False, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_agent_human_chat/scripts/test_billing_agent.py
+++ b/examples/multi_agent_human_chat/scripts/test_billing_agent.py
@@ -1,0 +1,15 @@
+"""Run tests for the Billing Agent."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    test_path = repo_root / "agents" / "billing"
+    subprocess.run([sys.executable, "-m", "pytest", str(test_path), "-s"], check=False, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_agent_human_chat/scripts/test_claims_agent.py
+++ b/examples/multi_agent_human_chat/scripts/test_claims_agent.py
@@ -1,0 +1,15 @@
+"""Run tests for the Claims Agent."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    test_path = repo_root / "agents" / "claims"
+    subprocess.run([sys.executable, "-m", "pytest", str(test_path), "-s"], check=False, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_agent_human_chat/scripts/test_escalation_agent.py
+++ b/examples/multi_agent_human_chat/scripts/test_escalation_agent.py
@@ -1,0 +1,15 @@
+"""Run tests for the Escalation Agent."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    test_path = repo_root / "agents" / "escalation"
+    subprocess.run([sys.executable, "-m", "pytest", str(test_path), "-s"], check=False, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_agent_human_chat/scripts/test_frontend_agent.py
+++ b/examples/multi_agent_human_chat/scripts/test_frontend_agent.py
@@ -1,0 +1,15 @@
+"""Run tests for the Frontend Agent."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    test_path = repo_root / "agents" / "frontend"
+    subprocess.run([sys.executable, "-m", "pytest", str(test_path), "-s"], check=False, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_agent_human_chat/scripts/test_policies_agent.py
+++ b/examples/multi_agent_human_chat/scripts/test_policies_agent.py
@@ -1,0 +1,15 @@
+"""Run tests for the Policies Agent."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    test_path = repo_root / "agents" / "policies"
+    subprocess.run([sys.executable, "-m", "pytest", str(test_path), "-s"], check=False, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi_agent_human_chat/scripts/test_triage_agent.py
+++ b/examples/multi_agent_human_chat/scripts/test_triage_agent.py
@@ -1,0 +1,15 @@
+"""Run tests for the Triage Agent."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    test_path = repo_root / "agents" / "triage"
+    subprocess.run([sys.executable, "-m", "pytest", str(test_path), "-s"], check=False, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- place example scripts under multi_agent_human_chat/scripts
- update Makefile, Dockerfile, Helm chart and tests to use `scripts.start_policies`
- provide helper scripts to run agent tests

## Testing
- `ruff check examples/multi_agent_human_chat/scripts/start_policies.py`
- `ruff check .` *(fails: F401 etc.)*
- `make -C examples/multi_agent_human_chat lint` *(fails: missing venv)*

------
https://chatgpt.com/codex/tasks/task_e_68653a9348b48328bd6d8a47a27331dc