### PR TITLE
Fix frontend agent logger

### DIFF
--- a/examples/multi_agent_human_chat/agents/frontend/agent.py
+++ b/examples/multi_agent_human_chat/agents/frontend/agent.py
@@ -38,6 +38,7 @@ eggai_set_default_transport(
 )
 
 frontend_agent = Agent("FrontendAgent")
+frontend_agent.logger = logger  # expose logger on the agent instance
 human_channel = Channel("human")
 human_stream_channel = Channel("human_stream")
 websocket_manager = WebSocketManager()


### PR DESCRIPTION
## Summary
- expose a logger on `frontend_agent`

## Testing
- `make test-example EXAMPLE=multi_agent_human_chat` *(fails: No tests found)*
- `python3 -m scripts.run_all_tests` *(fails to install dependencies, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68656e02d5848328ac1e80db9b8cebf6