### PR TITLE
Fix frontend agent exports

### DIFF
--- a/examples/multi_agent_human_chat/agents/frontend/agent.py
+++ b/examples/multi_agent_human_chat/agents/frontend/agent.py
@@ -53,9 +53,16 @@ init_token_metrics(
 from . import handlers  # noqa: E402,F401
 from .gateway import add_websocket_gateway  # noqa: E402
 
+# Re-export handler functions for backwards compatibility
+handle_human_messages = handlers.handle_human_messages
+handle_human_stream_messages = handlers.handle_human_stream_messages
+
 __all__ = [
     "frontend_agent",
     "add_websocket_gateway",
     "human_channel",
     "human_stream_channel",
+    "handle_human_messages",
+    "handle_human_stream_messages",
+    "messages_cache",
 ]


### PR DESCRIPTION
## Summary
- re-export handler functions from `frontend.agent`
- expose them in `__all__`

## Testing
- `pytest -vv examples/multi_agent_human_chat/agents/frontend/tests/test_agent.py::test_handle_human_messages`

------
https://chatgpt.com/codex/tasks/task_e_686571d76e58832891cf531dc08b5226