### PR TITLE
Refactor/EN-48 claims agent

### DIFF
--- a/examples/multi_agent_human_chat/agents/claims/agent.py
+++ b/examples/multi_agent_human_chat/agents/claims/agent.py
@@ -43,10 +43,11 @@ def get_conversation_string(chat_messages: List[ChatMessage]) -> str:
             return ""
 
         conversation_parts = []
-        for chat in chat_messages:
+        for idx, chat in enumerate(chat_messages):
             if "content" not in chat:
-                safe_set_attribute(span, "invalid_message", True)
-                continue
+                safe_set_attribute(span, "invalid_message_index", idx)
+                span.set_status(1, "Invalid chat message: missing content")
+                raise ValueError(f"Chat message at index {idx} is missing 'content'")
 
             role = chat.get("role", "User")
             conversation_parts.append(f"{role}: {chat['content']}")

--- a/examples/multi_agent_human_chat/agents/claims/agent.py
+++ b/examples/multi_agent_human_chat/agents/claims/agent.py
@@ -203,12 +203,15 @@ async def handle_claim_request(msg: TracedMessage) -> None:
                 type="agent_message",
                 source="ClaimsAgent",
                 data={
-                    "message": "I apologize, but I'm having trouble processing your request right now. Please try again.",
-                    "connection_id": locals().get("connection_id", "unknown"),
+                    "message": (
+                        "I apologize, but I'm having trouble processing your request right now. "
+                        "Please try again."
+                    ),
+                    "connection_id": connection_id,
                     "agent": "ClaimsAgent",
                 },
-                traceparent=msg.traceparent if "msg" in locals() else None,
-                tracestate=msg.tracestate if "msg" in locals() else None,
+                traceparent=msg.traceparent,
+                tracestate=msg.tracestate,
             )
         )
 

--- a/examples/multi_agent_human_chat/agents/claims/config.py
+++ b/examples/multi_agent_human_chat/agents/claims/config.py
@@ -1,10 +1,8 @@
 from typing import Optional
 
-from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-load_dotenv()
 
 
 class Settings(BaseSettings):

--- a/examples/multi_agent_human_chat/agents/claims/config.py
+++ b/examples/multi_agent_human_chat/agents/claims/config.py
@@ -4,7 +4,6 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-
 class Settings(BaseSettings):
     app_name: str = Field(default="claims_agent")
 

--- a/examples/multi_agent_human_chat/agents/claims/config.py
+++ b/examples/multi_agent_human_chat/agents/claims/config.py
@@ -13,10 +13,8 @@ class Settings(BaseSettings):
     language_model_api_base: Optional[str] = Field(default=None)
     cache_enabled: bool = Field(default=False)
 
-    # Kafka transport settings
+    # Kafka transport settings (used by create_kafka_transport)
     kafka_bootstrap_servers: str = Field(default="localhost:19092")
-    kafka_topic_prefix: str = Field(default="eggai")
-    kafka_rebalance_timeout_ms: int = Field(default=20000)
     kafka_ca_content: str = Field(default="")
 
     # Observability settings
@@ -26,8 +24,6 @@ class Settings(BaseSettings):
         default=9092, description="Port for Prometheus metrics server"
     )
 
-    # Claims specific settings
-    claims_database_path: str = Field(default="")
 
     model_config = SettingsConfigDict(
         env_prefix="CLAIMS_", env_file=".env", env_ignore_empty=True, extra="ignore"

--- a/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims.py
+++ b/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims.py
@@ -8,7 +8,6 @@ from typing import Any, AsyncIterable, Dict, Optional, Union
 import dspy
 from dspy import Prediction
 from dspy.streaming import StreamResponse
-from pydantic import BaseModel, Field
 
 from agents.claims.config import settings
 from libraries.dspy_set_language_model import dspy_set_language_model
@@ -16,27 +15,12 @@ from libraries.logger import get_console_logger
 from libraries.tracing import TracedReAct, create_tracer, traced_dspy_function
 from libraries.tracing.otel import safe_set_attribute
 
+from agents.claims.types import ModelConfig
+
 logger = get_console_logger("claims_agent.dspy")
 
 
-class ModelConfig(BaseModel):
-    """Configuration for the claims DSPy model."""
-
-    name: str = Field("claims_react", description="Name of the model")
-    max_iterations: int = Field(
-        5, description="Maximum iterations for the model", ge=1, le=10
-    )
-    use_tracing: bool = Field(True, description="Whether to trace model execution")
-    cache_enabled: bool = Field(False, description="Whether to enable model caching")
-    truncation_length: int = Field(
-        15000, description="Maximum length for conversation history", ge=1000
-    )
-    timeout_seconds: float = Field(
-        30.0, description="Timeout for model inference in seconds", ge=1.0
-    )
-
-
-DEFAULT_CONFIG = ModelConfig()
+DEFAULT_CONFIG = ModelConfig(name="claims_react")
 
 
 class ClaimsSignature(dspy.Signature):

--- a/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims.py
+++ b/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims.py
@@ -10,12 +10,11 @@ from dspy import Prediction
 from dspy.streaming import StreamResponse
 
 from agents.claims.config import settings
+from agents.claims.types import ModelConfig
 from libraries.dspy_set_language_model import dspy_set_language_model
 from libraries.logger import get_console_logger
 from libraries.tracing import TracedReAct, create_tracer, traced_dspy_function
 from libraries.tracing.otel import safe_set_attribute
-
-from agents.claims.types import ModelConfig
 
 logger = get_console_logger("claims_agent.dspy")
 

--- a/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_data.py
+++ b/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_data.py
@@ -1,10 +1,9 @@
 """Claims data store and tools for claim operations."""
 
 import json
-import re
 from typing import Dict, List, Optional, Tuple, Union
 
-from pydantic import BaseModel, Field, field_validator
+from agents.claims.types import ClaimRecord
 
 from libraries.logger import get_console_logger
 from libraries.tracing import create_tracer
@@ -12,64 +11,6 @@ from libraries.tracing.otel import safe_set_attribute
 
 from .claims_errors import ErrorCategory, ErrorResponse, get_user_friendly_error
 
-logger = get_console_logger("claims_agent.data")
-tracer = create_tracer("claims_agent_data")
-
-
-class ClaimRecord(BaseModel):
-    """Data structure for an insurance claim record with validation."""
-
-    claim_number: str = Field(..., description="Unique identifier for the claim")
-    policy_number: str = Field(
-        ..., description="Policy number associated with the claim"
-    )
-    status: str = Field(..., description="Current status of the claim")
-    next_steps: str = Field(..., description="Next steps required for claim processing")
-    outstanding_items: List[str] = Field(
-        default_factory=list, description="Items pending for claim processing"
-    )
-    estimate: Optional[float] = Field(None, description="Estimated payout amount", gt=0)
-    estimate_date: Optional[str] = Field(
-        None, description="Estimated date for payout (YYYY-MM-DD)"
-    )
-    details: Optional[str] = Field(
-        None, description="Detailed description of the claim"
-    )
-    address: Optional[str] = Field(None, description="Address related to the claim")
-    phone: Optional[str] = Field(None, description="Contact phone number")
-    damage_description: Optional[str] = Field(
-        None, description="Description of damage or loss"
-    )
-    contact_email: Optional[str] = Field(None, description="Contact email address")
-
-    @field_validator("estimate_date")
-    @classmethod
-    def validate_date_format(cls, v):
-        """Validate date is in YYYY-MM-DD format."""
-        if v is None:
-            return v
-        if not re.match(r"^\d{4}-\d{2}-\d{2}$", v):
-            raise ValueError("Date must be in YYYY-MM-DD format")
-        return v
-
-    @field_validator("phone")
-    @classmethod
-    def validate_phone(cls, v):
-        """Validate phone number format."""
-        if v is None:
-            return v
-        # Simple validation - could be enhanced with country-specific patterns
-        if not re.match(r"^\+?[\d\-\(\) ]{7,}$", v):
-            raise ValueError("Invalid phone number format")
-        return v
-
-    def to_dict(self) -> Dict:
-        """Convert claim record to dictionary, excluding None values."""
-        return {k: v for k, v in self.model_dump().items() if v is not None}
-
-    def to_json(self) -> str:
-        """Convert claim record to JSON string."""
-        return json.dumps(self.to_dict())
 
 
 # Sample in-memory claims database

--- a/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_data.py
+++ b/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_data.py
@@ -10,6 +10,7 @@ from libraries.tracing import create_tracer
 from libraries.tracing.otel import safe_set_attribute
 
 from .claims_errors import ErrorCategory, ErrorResponse, get_user_friendly_error
+from .claims_validators import FieldValidators, FIELD_VALIDATORS, ALLOWED_FIELDS
 
 
 
@@ -157,77 +158,6 @@ def file_claim(policy_number: str, claim_details: str) -> str:
         return format_error_response(ErrorResponse.GENERIC_ERROR)
 
 
-# Field validators registry
-class FieldValidators:
-    """Validation functions for claim fields."""
-
-    @staticmethod
-    def validate_estimate(value: str) -> Tuple[bool, Optional[Union[str, float]]]:
-        """Validate estimate field value."""
-        try:
-            amount = float(value)
-            if amount < 0:
-                return False, "Estimate cannot be negative"
-            return True, amount
-        except ValueError:
-            return False, "Estimate must be a valid number"
-
-    @staticmethod
-    def validate_date(value: str) -> Tuple[bool, Optional[str]]:
-        """Validate date field value."""
-        if not (value.count("-") == 2 and len(value) >= 8):
-            return False, "Date must be in YYYY-MM-DD format"
-        try:
-            # Basic validation that could be expanded
-            year, month, day = value.split("-")
-            if not (
-                1900 <= int(year) <= 2100
-                and 1 <= int(month) <= 12
-                and 1 <= int(day) <= 31
-            ):
-                return False, "Date values out of range"
-            return True, value
-        except ValueError:
-            return False, "Invalid date format, use YYYY-MM-DD"
-
-    @staticmethod
-    def validate_items_list(value: str) -> Tuple[bool, Optional[List[str]]]:
-        """Validate a comma-separated list of items."""
-        if not value or not value.strip():
-            return False, "Please provide at least one item"
-        items = [item.strip() for item in value.split(",") if item.strip()]
-        if not items:
-            return False, "Please provide at least one item"
-        return True, items
-
-    @staticmethod
-    def validate_text(value: str) -> Tuple[bool, Optional[str]]:
-        """Validate and sanitize text fields."""
-        clean_value = value.strip()
-        if not clean_value:
-            return False, "Value cannot be empty"
-        if len(clean_value) > 1000:  # Set reasonable limit
-            return False, "Value is too long (max 1000 characters)"
-        return True, clean_value
-
-
-# Field validation registry
-FIELD_VALIDATORS = {
-    "estimate": FieldValidators.validate_estimate,
-    "estimate_date": FieldValidators.validate_date,
-    "outstanding_items": FieldValidators.validate_items_list,
-    "policy_number": FieldValidators.validate_text,
-    "status": FieldValidators.validate_text,
-    "details": FieldValidators.validate_text,
-    "address": FieldValidators.validate_text,
-    "phone": FieldValidators.validate_text,
-    "damage_description": FieldValidators.validate_text,
-    "contact_email": FieldValidators.validate_text,
-    "next_steps": FieldValidators.validate_text,
-}
-
-# Explicitly allowed fields to update
-ALLOWED_FIELDS = list(FIELD_VALIDATORS.keys())
 
 
 @tracer.start_as_current_span("update_field_value")

--- a/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_data.py
+++ b/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_data.py
@@ -1,18 +1,20 @@
 """Claims data store and tools for claim operations."""
 
 import json
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Tuple
 
 from agents.claims.types import ClaimRecord
 
+# Logging and tracing setup
 from libraries.logger import get_console_logger
 from libraries.tracing import create_tracer
 from libraries.tracing.otel import safe_set_attribute
 
 from .claims_errors import ErrorCategory, ErrorResponse, get_user_friendly_error
-from .claims_validators import FieldValidators, FIELD_VALIDATORS, ALLOWED_FIELDS
+from .claims_validators import ALLOWED_FIELDS, FIELD_VALIDATORS, FieldValidators
 
-
+logger = get_console_logger("claims_agent.data")
+tracer = create_tracer("claims_agent_data")
 
 # Sample in-memory claims database
 CLAIMS_DATABASE = [

--- a/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_validators.py
+++ b/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_validators.py
@@ -1,0 +1,75 @@
+"""Field validators and registry for the Claims Agent."""
+
+import re
+from typing import List, Optional, Tuple, Union
+
+
+class FieldValidators:
+    """Validation functions for claim fields."""
+
+    @staticmethod
+    def validate_estimate(value: str) -> Tuple[bool, Optional[Union[str, float]]]:
+        """Validate estimate field value."""
+        try:
+            amount = float(value)
+            if amount < 0:
+                return False, "Estimate cannot be negative"
+            return True, amount
+        except ValueError:
+            return False, "Estimate must be a valid number"
+
+    @staticmethod
+    def validate_date(value: str) -> Tuple[bool, Optional[str]]:
+        """Validate date field value."""
+        if not (value.count("-") == 2 and len(value) >= 8):
+            return False, "Date must be in YYYY-MM-DD format"
+        try:
+            year, month, day = value.split("-")
+            if not (
+                1900 <= int(year) <= 2100
+                and 1 <= int(month) <= 12
+                and 1 <= int(day) <= 31
+            ):
+                return False, "Date values out of range"
+            return True, value
+        except ValueError:
+            return False, "Invalid date format, use YYYY-MM-DD"
+
+    @staticmethod
+    def validate_items_list(value: str) -> Tuple[bool, Optional[List[str]]]:
+        """Validate a comma-separated list of items."""
+        if not value or not value.strip():
+            return False, "Please provide at least one item"
+        items = [item.strip() for item in value.split(",") if item.strip()]
+        if not items:
+            return False, "Please provide at least one item"
+        return True, items
+
+    @staticmethod
+    def validate_text(value: str) -> Tuple[bool, Optional[str]]:
+        """Validate and sanitize text fields."""
+        clean_value = value.strip()
+        if not clean_value:
+            return False, "Value cannot be empty"
+        if len(clean_value) > 1000:
+            return False, "Value is too long (max 1000 characters)"
+        return True, clean_value
+
+
+# Field validation registry mapping field names to validators
+FIELD_VALIDATORS = {
+    "estimate": FieldValidators.validate_estimate,
+    "estimate_date": FieldValidators.validate_date,
+    "outstanding_items": FieldValidators.validate_items_list,
+    "policy_number": FieldValidators.validate_text,
+    "status": FieldValidators.validate_text,
+    "details": FieldValidators.validate_text,
+    "address": FieldValidators.validate_text,
+    "phone": FieldValidators.validate_text,
+    "damage_description": FieldValidators.validate_text,
+    "contact_email": FieldValidators.validate_text,
+    "next_steps": FieldValidators.validate_text,
+}
+
+# Explicitly allowed fields to update (security whitelist)
+ALLOWED_FIELDS = list(FIELD_VALIDATORS.keys())

--- a/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_validators.py
+++ b/examples/multi_agent_human_chat/agents/claims/dspy_modules/claims_validators.py
@@ -1,6 +1,5 @@
 """Field validators and registry for the Claims Agent."""
 
-import re
 from typing import List, Optional, Tuple, Union
 
 

--- a/examples/multi_agent_human_chat/agents/claims/main.py
+++ b/examples/multi_agent_human_chat/agents/claims/main.py
@@ -30,6 +30,10 @@ async def main():
     # Initialize telemetry and language model
     init_telemetry(app_name=settings.app_name, endpoint=settings.otel_endpoint)
     dspy_set_language_model(settings)
+    # Load optimized DSPy prompts if available
+    from agents.claims.dspy_modules.claims import load_optimized_prompts
+
+    load_optimized_prompts()
 
     # Start the agent
     await claims_agent.start()

--- a/examples/multi_agent_human_chat/agents/claims/tests/test_agent_additional.py
+++ b/examples/multi_agent_human_chat/agents/claims/tests/test_agent_additional.py
@@ -137,11 +137,10 @@ def test_get_conversation_string_empty():
 
 
 def test_get_conversation_string_missing_content():
-    """Test get_conversation_string with missing content field."""
+    """Test get_conversation_string raises error when content is missing."""
     messages = [{"role": "user"}, {"role": "assistant", "content": "Hello"}]
-    result = get_conversation_string(messages)
-    assert "user:" not in result.lower()
-    assert "assistant: Hello" in result
+    with pytest.raises(ValueError, match="missing 'content'"):
+        get_conversation_string(messages)
 
 
 def test_get_conversation_string_normal():

--- a/examples/multi_agent_human_chat/agents/claims/types.py
+++ b/examples/multi_agent_human_chat/agents/claims/types.py
@@ -58,7 +58,9 @@ ValidatorFunction = Callable[[str], ValidatorResult]
 class ModelConfig(BaseModel):
     """Configuration for the claims DSPy model."""
 
-    name: str = Field(..., description="Name of the model")
+    name: str = Field(
+        "claims_react", description="Name of the model"
+    )
     max_iterations: int = Field(
         5, description="Maximum iterations for the model", ge=1, le=10
     )


### PR DESCRIPTION
## Cleanup & Refactor Claims Agent

### ✅ Priority 1 — Critical Cleanup & Model-Type Unification

- [x] **Unify duplicate `ModelConfig` definitions**
  - Move `ModelConfig` from `dspy_modules/claims.py` into `types.py`.
  - Ensure all modules use the unified import.

- [x] **Unify duplicate `ClaimRecord` definitions**
  - Remove redundant `ClaimRecord` from `claims_data.py` and use the one in `types.py`.

- [x] **Remove redundant `load_dotenv()`**
  - Delete `load_dotenv()` from `config.py`, since Pydantic handles `.env` loading.

- [x] **Eliminate unused settings fields**
  - Remove `claims_database_path` and `kafka_topic_prefix` if they are unused.

- [x] **Harden exception handling in `process_claims_request`**
  - Avoid `locals()` and refactor to use explicit `connection_id`, `message_id` context variables.

---

### 🏗 Priority 2 — Code Structure & Readability

- [x] **Refactor `agent.py` to DRY common messaging logic**
  - Extract repeated `TracedMessage(...)` + `publish()` blocks into helper functions.

- [x] **Strengthen `get_conversation_string` validation**
  - Raise an error if a message is missing `"content"` instead of skipping silently.

- [x] **Simplify DSPy prompt-loading logic**
  - Move JSON prompt loading in `claims.py` into a proper init function.

- [ ] **Separate sample data from logic**
  - Move `CLAIMS_DATABASE` sample records to a test fixture or initializer.

- [x] **Modularize field validators**
  - Move `FieldValidators` and `FIELD_VALIDATORS` into their own validation module.

- [ ] **Seed randomness in `create_claims_dataset()`**
  - Add a `seed` argument to make dataset generation deterministic.

---

### 📝 Priority 4 — Documentation & Style

- [ ] **Update and prune `README.md`**
  - Ensure all referenced commands exist

- [x] **Remove unused imports and variables**
  - Clean up dead code and unused imports for better clarity.
