### PR TITLE
Refactor/EN-51 triage agent

### DIFF
--- a/examples/multi_agent_human_chat/agents/triage/agent.py
+++ b/examples/multi_agent_human_chat/agents/triage/agent.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import dspy.streaming
 from eggai import Agent, Channel
 from eggai.transport import eggai_set_default_transport
@@ -196,16 +194,3 @@ async def handle_others(msg: TracedMessage):
     logger.debug("Received message: %s", msg)
 
 
-if __name__ == "__main__":
-
-    async def run():
-        print("Testing chunked chatty:")
-        chunks = chatty(chat_history="User: Hello!")
-        async for chunk in chunks:
-            if isinstance(chunk, dspy.streaming.StreamResponse):
-                print(chunk.chunk, end="")
-            elif isinstance(chunk, dspy.Prediction):
-                print("")
-                print(chunk.get_lm_usage())
-
-    asyncio.run(run())

--- a/examples/multi_agent_human_chat/agents/triage/agent.py
+++ b/examples/multi_agent_human_chat/agents/triage/agent.py
@@ -1,7 +1,6 @@
 """Triage agent handler: classify user messages and route or stream responses."""
 import dspy.streaming
 from eggai import Agent, Channel
-from eggai.transport import eggai_set_default_transport
 from opentelemetry import trace
 
 from agents.triage.config import settings
@@ -10,10 +9,8 @@ from agents.triage.models import AGENT_REGISTRY, TargetAgent
 import importlib
 from typing import Callable, Any, List, Dict
 from libraries.channels import channels
-from libraries.kafka_transport import create_kafka_transport
 from libraries.logger import get_console_logger
 from libraries.tracing import TracedMessage, format_span_as_traceparent, traced_handler
-from libraries.tracing.init_metrics import init_token_metrics
 
 # Lazy-loaded classifier registry: maps version to (module path, function name)
 _CLASSIFIER_PATHS = {
@@ -122,16 +119,6 @@ async def _stream_chatty_response(
                 )
                 logger.info(
 
-init_token_metrics(
-    port=settings.prometheus_metrics_port, application_name=settings.app_name
-)
-
-eggai_set_default_transport(
-    lambda: create_kafka_transport(
-        bootstrap_servers=settings.kafka_bootstrap_servers,
-        ssl_cert=settings.kafka_ca_content,
-    )
-)
 
 triage_agent = Agent(name="TriageAgent")
 human_channel = Channel(channels.human)

--- a/examples/multi_agent_human_chat/agents/triage/attention_net/config.py
+++ b/examples/multi_agent_human_chat/agents/triage/attention_net/config.py
@@ -5,7 +5,6 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-
 class AttentionNetSettings(BaseSettings):
     # Model configuration
     n_classes: int = Field(default=5)

--- a/examples/multi_agent_human_chat/agents/triage/attention_net/config.py
+++ b/examples/multi_agent_human_chat/agents/triage/attention_net/config.py
@@ -1,11 +1,9 @@
 import datetime
 import os
 
-from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-load_dotenv()
 
 
 class AttentionNetSettings(BaseSettings):

--- a/examples/multi_agent_human_chat/agents/triage/baseline_model/config.py
+++ b/examples/multi_agent_human_chat/agents/triage/baseline_model/config.py
@@ -2,11 +2,9 @@ import datetime
 import os
 from typing import List, Optional, Union
 
-from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-load_dotenv()
 
 
 class FewshotSettings(BaseSettings):

--- a/examples/multi_agent_human_chat/agents/triage/baseline_model/config.py
+++ b/examples/multi_agent_human_chat/agents/triage/baseline_model/config.py
@@ -6,7 +6,6 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-
 class FewshotSettings(BaseSettings):
     # Model configuration
     n_classes: int = Field(default=5)

--- a/examples/multi_agent_human_chat/agents/triage/main.py
+++ b/examples/multi_agent_human_chat/agents/triage/main.py
@@ -3,6 +3,8 @@ import asyncio  # noqa: I001 - agents import should be in specific order
 from eggai import eggai_main
 from eggai.transport import eggai_set_default_transport
 
+# Metrics, transport, and telemetry setup
+from libraries.tracing.init_metrics import init_token_metrics
 from libraries.dspy_set_language_model import dspy_set_language_model
 from libraries.kafka_transport import create_kafka_transport
 from libraries.logger import get_console_logger
@@ -10,6 +12,16 @@ from libraries.tracing import init_telemetry
 
 # Import settings first
 from agents.triage.config import settings
+
+# Configure transport and token metrics before importing the agent
+eggai_set_default_transport(
+    lambda: create_kafka_transport(
+        bootstrap_servers=settings.kafka_bootstrap_servers,
+        ssl_cert=settings.kafka_ca_content,
+    )
+)
+init_token_metrics(port=settings.prometheus_metrics_port, application_name=settings.app_name)
+
 from agents.triage.agent import triage_agent
 
 logger = get_console_logger("triage_agent")
@@ -17,23 +29,13 @@ logger = get_console_logger("triage_agent")
 
 @eggai_main
 async def main():
-    eggai_set_default_transport(
-        lambda: create_kafka_transport(
-            bootstrap_servers=settings.kafka_bootstrap_servers,
-            ssl_cert=settings.kafka_ca_content,
-        )
-    )
 
     logger.info(f"Starting {settings.app_name}")
 
+    # Initialize tracing, telemetry, and language model
     init_telemetry(app_name=settings.app_name, endpoint=settings.otel_endpoint)
     logger.info(f"Telemetry initialized for {settings.app_name}")
-
     dspy_set_language_model(settings)
-
-    logger.info(
-        f"Using Kafka transport with servers: {settings.kafka_bootstrap_servers}"
-    )
 
     await triage_agent.start()
     logger.info(f"{settings.app_name} started successfully")

--- a/examples/multi_agent_human_chat/agents/triage/tests/test_agent_utils.py
+++ b/examples/multi_agent_human_chat/agents/triage/tests/test_agent_utils.py
@@ -1,0 +1,46 @@
+import pytest
+
+from agents.triage.agent import (
+    _CLASSIFIER_PATHS,
+    build_conversation_string,
+    get_current_classifier,
+)
+from agents.triage.config import settings
+
+
+def test_build_conversation_string_empty():
+    # No messages yields empty string
+    assert build_conversation_string([]) == ""
+
+
+def test_build_conversation_string_basic():
+    msgs = [
+        {"agent": "User", "content": "Hello"},
+        {"agent": "Bot", "content": "Hi there!"},
+    ]
+    expected = "User: Hello\nBot: Hi there!\n"
+    assert build_conversation_string(msgs) == expected
+
+
+def test_build_conversation_string_filters_empty_content():
+    msgs = [
+        {"agent": "User", "content": ""},
+        {"agent": "Bot", "content": "Response"},
+    ]
+    expected = "Bot: Response\n"
+    assert build_conversation_string(msgs) == expected
+
+
+@pytest.mark.parametrize("version,module_fn", list(_CLASSIFIER_PATHS.items()))
+def test_get_current_classifier_valid(monkeypatch, version, module_fn):
+    # Ensure get_current_classifier returns a callable for each supported version
+    monkeypatch.setattr(settings, "classifier_version", version)
+    fn = get_current_classifier()
+    assert callable(fn)
+
+
+def test_get_current_classifier_invalid(monkeypatch):
+    # Unsupported version should raise ValueError
+    monkeypatch.setattr(settings, "classifier_version", "nonexistent")
+    with pytest.raises(ValueError):
+        get_current_classifier()


### PR DESCRIPTION
## Cleanup and Refactor Triage Agent

### 🔴 High‑Priority – Critical Cleanup and Fixes

- [ ] **Remove checked-in binary/model artifacts**
  - Delete `.pth`, `.pkl`, or other binary files and move to Git LFS or cloud storage.

- [x] **Fix or remove demo/test block in `agent.py`**
  - Move `if __name__ == "__main__"` demo code to a test or example script to avoid side effects on import.

---

### 🟠 Medium‑Priority – Structural Refactoring & Consistency

- [x] **Consolidate configuration definitions**
  - Unify the scattered Pydantic config files across submodules into one Settings model, or clearly separate their concerns.

- [x] **Refactor `get_current_classifier()` dynamic imports**
  - Replace long `if/elif` chains with a registry or plugin pattern for mapping versions.

- [x] **Extract conversation string builder into helper**
  - Avoid repeated `+=` concatenation; use `"\n".join([...])` for cleaner and faster chat history assembly.

- [x] **Break down `handle_user_message()`**
  - Split classification, routing, and streaming into smaller helper methods to reduce complexity.

- [x] **Add missing type annotations and docstrings**
  - Improve IDE and documentation support with return/argument types and module-level docstrings.

- [x] **Centralize tracing/telemetry init**
  - Use `init_token_metrics()`, `eggai_set_default_transport()`, etc. from libraries.

---

### 🟢 Low‑Priority – Enhancements & Polishing

- [x] **Harden error handling**
  - Avoid broad `except Exception:`; catch only expected exceptions with meaningful messages.

- [x] **Improve logging**
  - Use structured logging (`extra={}`) instead of interpolated f-strings.

- [-] **Strip outputs from notebooks or convert to `.py`**
  - Clean outputs or convert key notebooks to `.py` files to reduce history bloat.

- [-] **Modularize synthetic data generator/webserver**
  - Move `data_sets/synthetic/src/` logic to its own subpackage if used independently.

- [x] **Enhance test coverage**
  - Add tests for routing logic in `agent.py`, and validate startup behavior in `main.py`.
