### PR TITLE
feat: add Kafka topic management and ensure_exists API

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -11,12 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced release process with `make release VERSION=x.y.z` command
 - Changelog enforcement in CI for pull requests
 - Release candidate support with `make release-rc VERSION=x.y.zrc1`
+- `Channel.ensure_exists()` for pre-creating Kafka topics
 
 ### Changed
+- Kafka topics now auto-create on first use
 - Release workflow now uses git tags for versioning
 - Version now uses single source of truth (`pyproject.toml`) via `importlib.metadata`
 - Consolidated repository structure: removed duplicate docs from `sdk/`, moved to `docs/`
 - Moved issue templates from `sdk/.github/` to root `.github/`
+
+### Fixed
+- Redis transport parameter handling
 
 ## [0.2.8] - 2025-11-12
 

--- a/sdk/eggai/channel.py
+++ b/sdk/eggai/channel.py
@@ -93,6 +93,13 @@ class Channel:
         await self._get_transport().subscribe(self._name, callback, **kwargs)
         await self._ensure_connected()
 
+    async def ensure_exists(self):
+        """
+        Ensure the channel/topic exists without publishing or subscribing.
+        Useful for Kafka where topics need to exist before consumers start.
+        """
+        await self._get_transport().ensure_topic(self._name)
+
     async def stop(self):
         """
         Disconnects the channel's transport if connected.

--- a/sdk/eggai/transport/base.py
+++ b/sdk/eggai/transport/base.py
@@ -42,6 +42,13 @@ class Transport(ABC):
     ) -> Callable:
         """
         Subscribe to a channel with the given callback, invoked on new messages.
-        (No-op if a consumer doesn’t exist.)
+        (No-op if a consumer doesn't exist.)
+        """
+        pass
+
+    async def ensure_topic(self, channel: str):  # noqa: B027
+        """
+        Ensure a topic/channel exists. Default is no-op.
+        Override in transports that need explicit topic creation (e.g., Kafka).
         """
         pass

--- a/sdk/eggai/transport/redis.py
+++ b/sdk/eggai/transport/redis.py
@@ -199,7 +199,10 @@ class RedisTransport(Transport):
                     )
                 )
 
-        handler_id = kwargs.pop("handler_id")
+        handler_id = kwargs.pop("handler_id", None)
+
+        # Ignore Kafka-specific parameter (Redis uses 'group' for streams, not 'group_id')
+        kwargs.pop("group_id", None)
 
         # Extract stream-related parameters
         group = kwargs.pop("group", handler_id)


### PR DESCRIPTION
## Summary
- Add `ensure_topic()` to Transport base class for explicit topic creation
- Add `ensure_exists()` to Channel for public topic pre-creation API  
- Implement Kafka topic creation using `AIOKafkaAdminClient`
- Force producer metadata refresh after topic creation
- Set `metadata_max_age_ms=10000` default for faster metadata refresh
- Fix handler_id handling in Redis transport (ignore `group_id` parameter)

## Changes

### `eggai/channel.py`
- Added `ensure_exists()` method to pre-create topics before subscribing

### `eggai/transport/base.py`
- Added abstract `ensure_topic()` method with default no-op implementation

### `eggai/transport/kafka.py`
- Added topic management with `AIOKafkaAdminClient`
- Lazy topic creation on `publish()` and `subscribe()`
- Force metadata refresh after topic creation
- Added `_running` flag to prevent double connection

### `eggai/transport/redis.py`
- Fixed `handler_id` pop to use default `None`
- Added `group_id` parameter ignoring (Kafka-specific parameter)

## Test plan
- [x] Verified InMemory transport works
- [x] Verified Redis transport works
- [x] Verified Kafka transport creates topics correctly
- [x] Verified metadata refresh happens after topic creation