### PR TITLE
feat: PR-based release workflow with auto-tagging

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -1,0 +1,62 @@
+name: Auto Tag Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, 'chore: release v')
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from commit message
+        id: version
+        run: |
+          # Extract version from commit message "chore: release vX.Y.Z"
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          VERSION=$(echo "$COMMIT_MSG" | grep -oP 'chore: release v\K[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9]*' | head -1)
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from commit message"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Verify version matches pyproject.toml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PYPROJECT_VERSION=$(grep '^version = ' sdk/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+
+          if [ "$VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Version mismatch! Commit: $VERSION, pyproject.toml: $PYPROJECT_VERSION"
+            exit 1
+          fi
+          echo "Version verified: $VERSION"
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
+
+          # Check if tag already exists
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+          echo "Created and pushed tag: $TAG"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,13 +71,25 @@ jobs:
             exit 1
           fi
 
-      - name: Check [Unreleased] section has content
+      - name: Check changelog content
+        env:
+          IS_RELEASE: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
         run: |
-          if ! grep -A 10 "## \[Unreleased\]" sdk/CHANGELOG.md | grep -qE "^### "; then
-            echo "::error::Add your changes under [Unreleased] section in CHANGELOG.md"
-            exit 1
+          if [ "$IS_RELEASE" = "true" ]; then
+            # Release PRs: check that a new version section exists with date
+            if ! grep -qE "## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}" sdk/CHANGELOG.md; then
+              echo "::error::Release PR must have a version section with date (e.g., ## [0.2.9] - 2025-01-01)"
+              exit 1
+            fi
+            echo "Release changelog check passed!"
+          else
+            # Regular PRs: check [Unreleased] section has content
+            if ! grep -A 10 "## \[Unreleased\]" sdk/CHANGELOG.md | grep -qE "^### "; then
+              echo "::error::Add your changes under [Unreleased] section in CHANGELOG.md"
+              exit 1
+            fi
+            echo "Changelog check passed!"
           fi
-          echo "Changelog check passed!"
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Updates the release process to work with branch protection (PR required for main).

## Changes

### `.github/workflows/ci.yaml`
- Changelog check now handles release PRs differently
- PRs with `release` label check for version section instead of [Unreleased] content

### `.github/workflows/auto-tag.yaml` (new)
- Triggers on push to main
- Detects release commits (`chore: release v*`)
- Creates and pushes tag automatically
- Tag push triggers the publish workflow

### `Makefile`
- `make release VERSION=X.Y.Z` now creates a PR instead of direct push
- `make release-rc VERSION=X.Y.Zrc1` also uses PR flow
- After PR merge, tag is created automatically

## New Release Flow
```
make release VERSION=0.2.9
  → Creates release/v0.2.9 branch
  → Updates version + changelog
  → Creates PR with 'release' label
  → Merge PR
  → Auto-tag workflow creates v0.2.9 tag
  → Publish workflow releases to PyPI
```