### PR TITLE
feat: GitHub Actions based release workflow

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -1,0 +1,54 @@
+name: Auto Tag Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, 'chore: release v')
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version
+        id: version
+        run: |
+          # Extract version from commit message
+          VERSION=$(echo "${{ github.event.head_commit.message }}" | grep -oP 'chore: release v\K[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9]*' | head -1)
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from commit message"
+            exit 1
+          fi
+
+          # Verify it matches pyproject.toml
+          PYPROJECT_VERSION=$(grep '^version = ' sdk/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ "$VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Version mismatch: commit=$VERSION, pyproject.toml=$PYPROJECT_VERSION"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+          echo "Created tag: $TAG"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,13 +71,25 @@ jobs:
             exit 1
           fi
 
-      - name: Check [Unreleased] section has content
+      - name: Check changelog content
+        env:
+          IS_RELEASE: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
         run: |
-          if ! grep -A 10 "## \[Unreleased\]" sdk/CHANGELOG.md | grep -qE "^### "; then
-            echo "::error::Add your changes under [Unreleased] section in CHANGELOG.md"
-            exit 1
+          if [ "$IS_RELEASE" = "true" ]; then
+            # Release PRs: verify version section exists
+            if ! grep -qE "## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}" sdk/CHANGELOG.md; then
+              echo "::error::Release PR must have a version section (e.g., ## [0.2.9] - 2025-01-01)"
+              exit 1
+            fi
+            echo "Release changelog check passed!"
+          else
+            # Regular PRs: require content under [Unreleased]
+            if ! grep -A 10 "## \[Unreleased\]" sdk/CHANGELOG.md | grep -qE "^### "; then
+              echo "::error::Add your changes under [Unreleased] section in CHANGELOG.md"
+              exit 1
+            fi
+            echo "Changelog check passed!"
           fi
-          echo "Changelog check passed!"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,104 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 0.2.9 or 0.3.0rc1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if ! echo "$VERSION" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z]+[0-9]+)?$"; then
+            echo "::error::Invalid version format. Use: X.Y.Z or X.Y.Zrc1"
+            exit 1
+          fi
+
+      - name: Check for unreleased changes
+        id: check
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+
+          # Check if this is a prerelease
+          if echo "$VERSION" | grep -qE "(rc|alpha|beta)[0-9]+$"; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            # For stable releases, require changelog content
+            if ! grep -A 5 "## \[Unreleased\]" sdk/CHANGELOG.md | grep -qE "^### "; then
+              echo "::error::No changes found under [Unreleased] in CHANGELOG.md"
+              exit 1
+            fi
+          fi
+
+      - name: Create release branch
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git checkout -b release/v$VERSION
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          sed -i 's/^version = ".*"/version = "'$VERSION'"/' sdk/pyproject.toml
+
+      - name: Update CHANGELOG.md
+        if: steps.check.outputs.prerelease == 'false'
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          DATE=$(date +%Y-%m-%d)
+          sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" sdk/CHANGELOG.md
+
+      - name: Commit changes
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add sdk/pyproject.toml sdk/CHANGELOG.md
+          git commit -m "chore: release v$VERSION"
+
+      - name: Push branch
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          git push origin release/v$VERSION
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          PRERELEASE="${{ steps.check.outputs.prerelease }}"
+
+          if [ "$PRERELEASE" = "true" ]; then
+            gh pr create \
+              --title "chore: release v$VERSION" \
+              --body "Release candidate v$VERSION for testing.
+
+          Install with: \`pip install eggai==$VERSION\`" \
+              --label "release" \
+              --label "skip-changelog"
+          else
+            # Extract changelog for this version
+            CHANGELOG=$(sed -n "/## \[$VERSION\]/,/## \[/p" sdk/CHANGELOG.md | sed '$d' | tail -n +2)
+
+            gh pr create \
+              --title "chore: release v$VERSION" \
+              --body "## Release v$VERSION
+
+          $CHANGELOG" \
+              --label "release"
+          fi
+
+          echo "Release PR created! Merge it to trigger the release."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,25 +144,24 @@ fix: resolve issue with login timeout
 
 ### Releasing a New Version
 
-**Stable Release:**
-```bash
-make release VERSION=0.3.0
-```
+Releases are done via GitHub Actions:
 
-This command:
-1. Verifies you're on `main` branch with clean working directory
-2. Checks `[Unreleased]` section in CHANGELOG.md has content
-3. Updates version in `pyproject.toml`
-4. Converts `[Unreleased]` to `[VERSION] - DATE` in CHANGELOG.md
-5. Creates commit and tag `vVERSION`
-6. Pushes to origin (triggers PyPI publish and GitHub Release)
+1. Go to **Actions** → **Create Release PR**
+2. Click **Run workflow**
+3. Enter the version (e.g., `0.3.0` or `0.3.0rc1`)
+4. Click **Run workflow**
+
+This creates a PR that:
+- Updates `pyproject.toml` version
+- Updates `CHANGELOG.md` with release date (for stable releases)
+
+After merging the PR:
+- A tag is automatically created
+- PyPI publish is triggered
+- GitHub Release is created
 
 **Release Candidate (for testing):**
-```bash
-make release-rc VERSION=0.3.0rc1
-```
-
-Users can test with `pip install eggai==0.3.0rc1`. When stable, run `make release VERSION=0.3.0`.
+Use version format like `0.3.0rc1`. Users can test with `pip install eggai==0.3.0rc1`.
 
 ### Branch Protection Rules
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PYTHON ?= python3.12
 VENV_NAME ?= .venv
 
-.PHONY: install install-sdk install-docs test lint format clean deep-clean publish release release-rc
+.PHONY: install install-sdk install-docs test lint format build publish clean deep-clean
 
 # Install SDK and docs
 install: install-sdk install-docs
@@ -60,84 +60,3 @@ clean:
 deep-clean: clean
 	@echo "Removing virtual environments..."
 	find . -type d -name "$(VENV_NAME)" -exec rm -rf {} + 2>/dev/null || true
-
-# Release a new version
-# Usage: make release VERSION=0.2.9
-release:
-ifndef VERSION
-	$(error VERSION is required. Usage: make release VERSION=0.2.9)
-endif
-	@echo "Preparing release v$(VERSION)..."
-	@# Check we're on main branch
-	@if [ "$$(git branch --show-current)" != "main" ]; then \
-		echo "Error: Must be on main branch to release"; \
-		exit 1; \
-	fi
-	@# Check working directory is clean
-	@if [ -n "$$(git status --porcelain)" ]; then \
-		echo "Error: Working directory is not clean. Commit or stash changes first."; \
-		exit 1; \
-	fi
-	@# Check [Unreleased] section has content
-	@if ! grep -A 5 "## \[Unreleased\]" sdk/CHANGELOG.md | grep -qE "^### "; then \
-		echo "Error: No changes found under [Unreleased] in CHANGELOG.md"; \
-		exit 1; \
-	fi
-	@# Update version in pyproject.toml (single source of truth)
-	@sed -i.bak 's/^version = ".*"/version = "$(VERSION)"/' sdk/pyproject.toml && rm sdk/pyproject.toml.bak
-	@echo "Updated sdk/pyproject.toml"
-	@# Update CHANGELOG.md - replace [Unreleased] with [VERSION] - DATE
-	@DATE=$$(date +%Y-%m-%d); \
-	sed -i.bak "s/## \[Unreleased\]/## [Unreleased]\n\n## [$(VERSION)] - $$DATE/" sdk/CHANGELOG.md && rm sdk/CHANGELOG.md.bak
-	@echo "Updated sdk/CHANGELOG.md"
-	@# Commit and tag
-	@git add sdk/pyproject.toml sdk/CHANGELOG.md
-	@git commit -m "chore: release v$(VERSION)"
-	@git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
-	@echo "Created commit and tag v$(VERSION)"
-	@# Push
-	@git push origin main
-	@git push origin "v$(VERSION)"
-	@echo ""
-	@echo "Release v$(VERSION) complete!"
-	@echo "GitHub Actions will now build and publish to PyPI."
-
-# Release a release candidate for testing
-# Usage: make release-rc VERSION=0.3.0rc1
-release-rc:
-ifndef VERSION
-	$(error VERSION is required. Usage: make release-rc VERSION=0.3.0rc1)
-endif
-	@# Validate version format (must contain rc, alpha, or beta)
-	@if ! echo "$(VERSION)" | grep -qE "(rc|alpha|beta)[0-9]+$$"; then \
-		echo "Error: VERSION must be a pre-release (e.g., 0.3.0rc1, 0.3.0alpha1, 0.3.0beta1)"; \
-		exit 1; \
-	fi
-	@echo "Preparing release candidate v$(VERSION)..."
-	@# Check we're on main branch
-	@if [ "$$(git branch --show-current)" != "main" ]; then \
-		echo "Error: Must be on main branch to release"; \
-		exit 1; \
-	fi
-	@# Check working directory is clean
-	@if [ -n "$$(git status --porcelain)" ]; then \
-		echo "Error: Working directory is not clean. Commit or stash changes first."; \
-		exit 1; \
-	fi
-	@# Update version in pyproject.toml (single source of truth)
-	@sed -i.bak 's/^version = ".*"/version = "$(VERSION)"/' sdk/pyproject.toml && rm sdk/pyproject.toml.bak
-	@echo "Updated sdk/pyproject.toml"
-	@# Commit and tag (no changelog update for RCs)
-	@git add sdk/pyproject.toml
-	@git commit -m "chore: release candidate v$(VERSION)"
-	@git tag -a "v$(VERSION)" -m "Release candidate v$(VERSION)"
-	@echo "Created commit and tag v$(VERSION)"
-	@# Push
-	@git push origin main
-	@git push origin "v$(VERSION)"
-	@echo ""
-	@echo "Release candidate v$(VERSION) complete!"
-	@echo "GitHub Actions will now build and publish to PyPI as pre-release."
-	@echo ""
-	@echo "Users can test with: pip install eggai==$(VERSION)"
-	@echo "When ready for stable release: make release VERSION=<stable-version>"


### PR DESCRIPTION
## Summary
Replaces Makefile-based releases with GitHub Actions workflow.

## Changes

### New Workflows
- **release.yaml**: Triggered via workflow_dispatch from GitHub UI
  - Enter version, creates release PR automatically
  - Updates pyproject.toml and CHANGELOG.md
  - Adds 'release' label for CI detection

- **auto-tag.yaml**: Triggers on push to main
  - Detects release commits (`chore: release v*`)
  - Creates and pushes tag automatically
  - Tag triggers existing publish workflow

### Updated
- **ci.yaml**: Changelog check handles release PRs (with 'release' label)
- **Makefile**: Removed release/release-rc commands
- **CONTRIBUTING.md**: Updated release documentation

## New Release Flow
```
GitHub UI: Actions → Create Release PR → Run workflow
  ↓
PR created with version/changelog updates
  ↓
Merge PR
  ↓
Auto-tag creates vX.Y.Z tag
  ↓
Publish workflow releases to PyPI
```