### PR TITLE
chore: release v0.2.9

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2025-12-30
+
 ### Added
 - Enhanced release process with `make release VERSION=x.y.z` command
 - Changelog enforcement in CI for pull requests

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eggai"
-version = "0.2.8"
+version = "0.2.9"
 description = "EggAI Multi-Agent Meta Framework` is an async-first framework for building, deploying, and scaling multi-agent systems for modern enterprise environments"
 authors = ["Stefano Tucci <stefanotucci89@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Release v0.2.9

### Added
- `Channel.ensure_exists()` for pre-creating Kafka topics

### Changed
- Kafka topics now auto-create on first use

### Fixed
- Redis transport parameter handling