### PR TITLE
chore: standardize workflow dependencies

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: release-dists
           path: dist/
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
## Summary
- Standardize Poetry installation in ci.yaml to use `Gr1N/setup-poetry@v9` action instead of curl-based installation

This aligns ci.yaml with python-publish.yaml which already uses the action.

## Test plan
- [ ] CI passes with updated Poetry setup