### PR TITLE
chore: release v0.2.11

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-01-28
+
 ### Fixed
 - **RedisTransport**: Messages are no longer acknowledged when handlers raise exceptions
   - Set default `ack_policy` to `AckPolicy.NACK_ON_ERROR` for reliable message delivery

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eggai"
-version = "0.2.9"
+version = "0.2.11"
 description = "EggAI Multi-Agent Meta Framework` is an async-first framework for building, deploying, and scaling multi-agent systems for modern enterprise environments"
 authors = ["Stefano Tucci <stefanotucci89@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Release v0.2.11


### Fixed
- **RedisTransport**: Messages are no longer acknowledged when handlers raise exceptions
  - Set default `ack_policy` to `AckPolicy.NACK_ON_ERROR` for reliable message delivery
  - Failed messages now remain in the Pending Entries List (PEL) for redelivery
  - Added `min_idle_time` parameter support for automatic claiming of pending messages
  - Added test verifying error handling and message recovery behavior
