### PR TITLE
chore: release v0.2.12

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-03-12
+
 ### Added
 - **RedisTransport**: SDK-managed PEL reclaimer via new `retry_on_idle_ms` opt-in
   kwarg on `agent.subscribe()`. With `NACK_ON_ERROR` (the default), a handler

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eggai"
-version = "0.2.11"
+version = "0.2.12"
 description = "EggAI Multi-Agent Meta Framework` is an async-first framework for building, deploying, and scaling multi-agent systems for modern enterprise environments"
 authors = ["Stefano Tucci <stefanotucci89@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Release v0.2.12

### Added
- **RedisTransport**: Dead Letter Queue (DLQ) with configurable `max_retries`
  (default 5). Poison messages that exceed the retry limit are routed to a
  `{channel}.dlq` stream instead of retrying forever.
  - `max_retries=5` means 6 total handler calls (1 original + 5 retries); on the
    6th reclaim cycle the message is moved to the DLQ.
  - Set `max_retries=None` to disable the DLQ and get unlimited retries (previous behavior).
  - Optional `on_dlq` callback (sync or async) fires when a message lands in the DLQ.
  - Both reclaimers (main stream and retry stream) enforce the same threshold.
  - Unparseable messages (binary parse failure) return `_retry_count=0` and are never mistakenly routed to the DLQ.