### PR TITLE
fix(redis): parse binary envelope before calling on_dlq callback

### DIFF
--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -238,7 +238,18 @@ class PendingReclaimerManager:
                 )
                 if config.on_dlq is not None:
                     try:
-                        result = config.on_dlq(fields, msg_id_str, new_count)
+                        # Parse the binary envelope so the callback receives a
+                        # plain dict instead of raw bytes.
+                        parsed_msg: dict | bytes = fields
+                        if data_key in fields:
+                            try:
+                                body_bytes, _ = BinaryMessageFormatV1.parse(
+                                    fields[data_key]
+                                )
+                                parsed_msg = json.loads(body_bytes)
+                            except Exception:
+                                parsed_msg = fields
+                        result = config.on_dlq(parsed_msg, msg_id_str, new_count)
                         if asyncio.iscoroutine(result):
                             await result
                     except Exception:

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -654,7 +654,9 @@ async def test_max_retries_on_dlq_callback():
     dlq_callback_fired = asyncio.Event()
 
     async def my_on_dlq(fields, msg_id, retry_count):
-        callback_calls.append({"msg_id": msg_id, "retry_count": retry_count})
+        callback_calls.append(
+            {"fields": fields, "msg_id": msg_id, "retry_count": retry_count}
+        )
         dlq_callback_fired.set()
 
     @agent.subscribe(
@@ -683,6 +685,11 @@ async def test_max_retries_on_dlq_callback():
     assert callback_calls[0]["retry_count"] > 1, (
         f"Expected retry_count > 1, got {callback_calls[0]['retry_count']}"
     )
+    # on_dlq should receive a parsed dict, not raw bytes
+    fields = callback_calls[0]["fields"]
+    assert isinstance(fields, dict), f"Expected parsed dict, got {type(fields)}"
+    assert "test_id" in fields, f"Expected 'test_id' key in parsed message, got {fields.keys()}"
+    assert fields["test_id"] == test_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Parse the FastStream binary envelope before invoking the `on_dlq` callback so it receives a plain dict instead of raw `{b"__data__": <bytes>}`
- Adds test assertion verifying the callback receives a parsed dict with the original message keys

Follow-up to #190. Author: Rocky Jaiswal.