### PR TITLE
fix(ci): pin python version, artifact retention, skip-changelog label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check if changelog skip requested
+        id: skip-check
+        env:
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$PR_LABELS" | grep -q "skip-changelog"; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip-changelog label found, skipping changelog check"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check if changelog is required
+        if: steps.skip-check.outputs.skip != 'true'
         id: needs-changelog
         run: |
           # Changelog is required if the PR touches code or test files under sdk/
@@ -81,7 +94,7 @@ jobs:
           fi
 
       - name: Check CHANGELOG.md updated
-        if: steps.needs-changelog.outputs.required == 'true'
+        if: steps.skip-check.outputs.skip != 'true' && steps.needs-changelog.outputs.required == 'true'
         run: |
           if ! git diff origin/main --name-only | grep -q "sdk/CHANGELOG.md"; then
             echo "::error::CHANGELOG.md must be updated. Add your changes under [Unreleased] section."
@@ -89,7 +102,7 @@ jobs:
           fi
 
       - name: Check changelog content
-        if: steps.needs-changelog.outputs.required == 'true'
+        if: steps.skip-check.outputs.skip != 'true' && steps.needs-changelog.outputs.required == 'true'
         env:
           IS_RELEASE: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
         run: |

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -89,6 +89,7 @@ jobs:
         with:
           name: release-dists
           path: sdk/dist/
+          retention-days: 7
 
   create-tag:
     needs: [prepare, build-and-test]


### PR DESCRIPTION
- Add retention-days: 7 to artifact uploads in publish workflow
- Add skip-changelog label support in CI changelog job
- Gate all changelog check steps behind the skip-check condition