### PR TITLE
fix(redis): auto-recover from NOGROUP errors when Redis loses streams

### DIFF
--- a/docs/docs/sdk/redis-transport.md
+++ b/docs/docs/sdk/redis-transport.md
@@ -227,6 +227,18 @@ Guidelines:
 - `retry_reclaim_interval_s` controls how often the background reclaimer wakes up. Lower values increase Redis load; 15 s is a sensible default for most workloads.
 - `max_retries` prevents poison messages from looping forever. Set to `None` for unlimited retries (no DLQ).
 
+### Automatic Recovery from Redis Stream Loss (NOGROUP)
+
+If Redis loses streams mid-life — due to a restart without persistence, a failover, or memory eviction — FastStream's consume loop retries `XREADGROUP` but never re-runs `XGROUP CREATE`, resulting in an infinite `NOGROUP` error loop.
+
+The SDK handles this automatically with two mechanisms:
+
+1. **Background stream group monitor** — `RedisTransport` runs a lightweight background task that periodically calls `XGROUP CREATE` with `MKSTREAM` for every registered subscription. When groups already exist the call is a no-op (`BUSYGROUP`), so overhead under normal operation is negligible.
+
+2. **NOGROUP-aware reclaimer** — `PendingReclaimerManager` catches `NOGROUP` errors during reclaim cycles and recreates the consumer group instead of logging an unhandled exception every cycle.
+
+No configuration is needed — both mechanisms are always active when using `RedisTransport`.
+
 ### Constraints
 
 - `min_idle_time` (FastStream's built-in `XAUTOCLAIM`) and `retry_on_idle_ms` are **mutually exclusive** on the same subscription — mixing them raises `ValueError`.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **RedisTransport**: Auto-recover from NOGROUP errors when Redis loses streams
+  (restart without persistence, failover, memory eviction). A background stream
+  group monitor periodically ensures consumer groups exist via `XGROUP CREATE`
+  with `MKSTREAM`, and `PendingReclaimerManager` now recreates consumer groups
+  on NOGROUP errors instead of logging unhandled exceptions.
+
 ## [0.2.13] - 2026-03-14
 
 ### Changed

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -182,6 +182,12 @@ Two fields are injected on retry delivery to aid deduplication:
 `{channel}.dlq`. The DLQ is terminal — no automatic reclaimer. Set `max_retries=None` for
 unlimited retries. An optional `on_dlq` callback fires when a message lands in the DLQ.
 
+**Automatic recovery from Redis stream loss (NOGROUP):**
+If Redis loses streams (restart without persistence, failover, memory eviction), the SDK
+auto-recovers. A background monitor periodically ensures consumer groups exist via
+`XGROUP CREATE` with `MKSTREAM`, and the reclaimer recreates groups on `NOGROUP` errors.
+No configuration needed — always active with `RedisTransport`.
+
 **Constraints:**
 - `min_idle_time` (FastStream XAUTOCLAIM) and `retry_on_idle_ms` are mutually exclusive on the same subscription — mixing them raises `ValueError`.
 - Binary (non-UTF-8) field values are not supported; use JSON-serialisable payloads.

--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import redis.asyncio as aioredis
 from faststream.redis.parser.binary import BinaryMessageFormatV1
+from redis.exceptions import ResponseError
 
 logger = logging.getLogger(__name__)
 
@@ -166,10 +167,44 @@ class PendingReclaimerManager:
                 await self._reclaim_once(config)
             except asyncio.CancelledError:
                 raise
+            except ResponseError as e:
+                if "NOGROUP" in str(e):
+                    await self._ensure_group(config)
+                else:
+                    logger.exception(
+                        "Reclaimer error — stream=%s group=%s",
+                        config.stream,
+                        config.group,
+                    )
             except Exception:
                 logger.exception(
                     "Reclaimer error — stream=%s group=%s", config.stream, config.group
                 )
+
+    async def _ensure_group(self, config: ReclaimerConfig) -> None:
+        """Recreate a consumer group after a NOGROUP error (e.g. Redis restart).
+
+        Uses id="0" when the stream still has entries (partial group loss) so
+        unprocessed messages are redelivered.  Falls back to id="$" with
+        MKSTREAM when the stream itself is gone.
+        """
+        try:
+            stream_exists = await self._redis_client.exists(config.stream)
+            create_id = "0" if stream_exists else "$"
+            await self._redis_client.xgroup_create(
+                name=config.stream,
+                groupname=config.group,
+                id=create_id,
+                mkstream=True,
+            )
+            logger.info(
+                "Recreated consumer group %s on stream %s after NOGROUP error",
+                config.group,
+                config.stream,
+            )
+        except ResponseError as e:
+            if "BUSYGROUP" not in str(e):
+                raise
 
     async def _reclaim_once(self, config: ReclaimerConfig) -> None:
         # --- Paginated XPENDING scan ---

--- a/sdk/eggai/transport/redis.py
+++ b/sdk/eggai/transport/redis.py
@@ -1,9 +1,13 @@
+import asyncio
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
+import redis.asyncio as aioredis
 from faststream import AckPolicy
 from faststream.redis import RedisBroker, StreamSub
+from redis.exceptions import ResponseError
 
 from eggai.schemas import BaseMessage
 from eggai.transport.base import Transport
@@ -13,6 +17,17 @@ from eggai.transport.middleware_utils import (
     create_filter_middleware,
 )
 from eggai.transport.pending_reclaimer import PendingReclaimerManager, ReclaimerConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _StreamGroupInfo:
+    """Tracks a registered stream consumer group for health monitoring."""
+
+    stream_key: str
+    group: str
+    group_create_id: str
 
 
 class RedisTransport(Transport):
@@ -31,6 +46,7 @@ class RedisTransport(Transport):
         self,
         broker: RedisBroker | None = None,
         url: str = "redis://localhost:6379",
+        group_monitor_interval_s: float = 5.0,
         **kwargs,
     ):
         """
@@ -100,6 +116,9 @@ class RedisTransport(Transport):
         self._redis_url = url
         self._running = False
         self._reclaimer_manager: PendingReclaimerManager | None = None
+        self._stream_subscriptions: list[_StreamGroupInfo] = []
+        self._group_monitor_task: asyncio.Task | None = None
+        self._group_monitor_interval_s: float = group_monitor_interval_s
 
     async def connect(self):
         """
@@ -115,6 +134,11 @@ class RedisTransport(Transport):
         if self._reclaimer_manager is not None:
             await self._reclaimer_manager.start()
         self._running = True
+        if self._stream_subscriptions:
+            self._group_monitor_task = asyncio.create_task(
+                self._monitor_stream_groups(),
+                name="stream-group-monitor",
+            )
 
     async def disconnect(self):
         """
@@ -124,6 +148,13 @@ class RedisTransport(Transport):
         and to release any resources held by the RedisBroker.
         """
         self._running = False
+        if self._group_monitor_task is not None:
+            self._group_monitor_task.cancel()
+            try:
+                await self._group_monitor_task
+            except asyncio.CancelledError:
+                pass
+            self._group_monitor_task = None
         if self._reclaimer_manager is not None:
             await self._reclaimer_manager.stop()
         await self.broker.stop()
@@ -291,6 +322,17 @@ class RedisTransport(Transport):
             min_idle_time=min_idle_time,
         )
 
+        # Track the subscription so the background monitor can recreate the
+        # consumer group if Redis loses the stream (restart, failover, eviction).
+        if group:
+            self._stream_subscriptions.append(
+                _StreamGroupInfo(
+                    stream_key=self._get_stream_key(channel),
+                    group=group,
+                    group_create_id="$" if last_id == ">" else last_id,
+                )
+            )
+
         # Extract ack_policy or default to NACK_ON_ERROR for reliability
         # This ensures messages are NOT acknowledged when handlers raise exceptions,
         # allowing them to be redelivered for retry
@@ -358,6 +400,52 @@ class RedisTransport(Transport):
             )
 
         return registered_handler
+
+    async def _monitor_stream_groups(self) -> None:
+        """Periodically ensure all registered stream consumer groups exist.
+
+        When Redis loses streams (restart, failover, eviction), FastStream's
+        consume loop retries xreadgroup but never re-runs xgroup_create.
+        This monitor closes that gap by periodically attempting xgroup_create
+        for every registered subscription.  The call raises BUSYGROUP when the
+        group already exists, making it cheap under normal operation.
+
+        Uses id="0" when the stream still has entries (partial group loss) so
+        unprocessed messages are redelivered.  Falls back to the original
+        group_create_id with MKSTREAM when the stream itself is gone.
+        """
+        client = aioredis.from_url(self._redis_url, decode_responses=True)
+        try:
+            while self._running:
+                await asyncio.sleep(self._group_monitor_interval_s)
+                for info in self._stream_subscriptions:
+                    try:
+                        stream_exists = await client.exists(info.stream_key)
+                        create_id = "0" if stream_exists else info.group_create_id
+                        await client.xgroup_create(
+                            name=info.stream_key,
+                            groupname=info.group,
+                            id=create_id,
+                            mkstream=True,
+                        )
+                        logger.info(
+                            "Recreated missing consumer group %s on stream %s (id=%s)",
+                            info.group,
+                            info.stream_key,
+                            create_id,
+                        )
+                    except ResponseError as e:
+                        if "BUSYGROUP" not in str(e):
+                            logger.warning(
+                                "Failed to ensure consumer group %s on %s: %s",
+                                info.group,
+                                info.stream_key,
+                                e,
+                            )
+        except asyncio.CancelledError:
+            pass
+        finally:
+            await client.aclose()
 
     def _setup_reclaimer(
         self,

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -796,3 +796,217 @@ async def test_dlq_stream_naming():
         assert config.dlq_stream == "eggai.orders.dlq", (
             f"Expected dlq_stream='eggai.orders.dlq', got {config.dlq_stream}"
         )
+
+
+@pytest.mark.asyncio
+async def test_monitor_tracks_stream_subscriptions():
+    """subscribe() populates _stream_subscriptions for the group monitor."""
+    transport = RedisTransport()
+
+    async def handler(message):
+        return message
+
+    await transport.subscribe(
+        "orders",
+        handler,
+        handler_id="orders-handler-1",
+        retry_on_idle_ms=500,
+    )
+
+    # Main subscription + retry subscription
+    assert len(transport._stream_subscriptions) == 2
+    stream_keys = [s.stream_key for s in transport._stream_subscriptions]
+    assert "eggai.orders" in stream_keys
+    assert "eggai.orders.retry" in stream_keys
+
+    groups = [s.group for s in transport._stream_subscriptions]
+    assert "orders-handler-1" in groups
+    assert "orders-handler-1-retry" in groups
+
+    # Both use last_id=">" so group_create_id should be "$"
+    for sub in transport._stream_subscriptions:
+        assert sub.group_create_id == "$"
+
+
+@pytest.mark.asyncio
+async def test_nogroup_recovery_via_monitor():
+    """
+    When Redis loses a stream, the background group monitor should recreate
+    the consumer group so that FastStream's consume loop recovers without
+    a pod restart.
+    """
+    redis_client = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+    test_id = uuid.uuid4().hex[:8]
+    channel_name = f"test-nogroup-{test_id}"
+    stream_name = f"eggai.{channel_name}"
+
+    transport = RedisTransport(group_monitor_interval_s=1.0)
+    agent = Agent(f"nogroup-agent-{test_id}", transport=transport)
+    channel = Channel(channel_name, transport=transport)
+
+    first_msg = asyncio.Event()
+    second_msg = asyncio.Event()
+
+    @agent.subscribe(channel=channel)
+    async def handler(message):
+        if first_msg.is_set():
+            second_msg.set()
+        else:
+            first_msg.set()
+
+    await agent.start()
+
+    # Verify initial message processing works
+    await channel.publish({"type": "test", "data": "before-delete", "test_id": test_id})
+    await asyncio.wait_for(first_msg.wait(), timeout=5.0)
+    assert first_msg.is_set()
+
+    # Simulate Redis data loss by deleting the stream
+    await redis_client.delete(stream_name)
+
+    # Wait for the monitor to recreate the group (interval=1s + FastStream retry~4.5s)
+    await asyncio.sleep(12)
+
+    # Publish a new message — should be processed after recovery
+    await channel.publish(
+        {"type": "test", "data": "after-recovery", "test_id": test_id}
+    )
+
+    try:
+        await asyncio.wait_for(second_msg.wait(), timeout=10.0)
+    except asyncio.TimeoutError:
+        pass
+
+    await agent.stop()
+    await redis_client.aclose()
+
+    assert second_msg.is_set(), "Expected second message to be set"
+
+
+@pytest.mark.asyncio
+async def test_reclaimer_nogroup_recovery():
+    """
+    When the reclaimer encounters a NOGROUP error it should recreate the
+    consumer group and continue on the next cycle instead of logging an
+    unhandled exception every interval.
+    """
+    from eggai.transport.pending_reclaimer import (
+        PendingReclaimerManager,
+        ReclaimerConfig,
+    )
+
+    redis_client = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+    test_id = uuid.uuid4().hex[:8]
+    stream_name = f"eggai.test-reclaimer-nogroup-{test_id}"
+    group_name = f"test-group-{test_id}"
+
+    # Create a stream and consumer group, then delete the stream
+    await redis_client.xgroup_create(stream_name, group_name, id="$", mkstream=True)
+    await redis_client.delete(stream_name)
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    manager.add(
+        ReclaimerConfig(
+            stream=stream_name,
+            group=group_name,
+            consumer=f"{group_name}-reclaimer",
+            retry_stream=f"{stream_name}.retry",
+            min_idle_ms=1000,
+            interval_s=0.5,
+        )
+    )
+
+    await manager.start()
+    # Give the reclaimer time to hit NOGROUP and recover
+    await asyncio.sleep(2)
+    await manager.stop()
+
+    # The reclaimer should have recreated the group
+    groups = await redis_client.xinfo_groups(stream_name)
+    group_names = [
+        g["name"] if isinstance(g["name"], str) else g["name"].decode() for g in groups
+    ]
+    assert group_name in group_names, (
+        f"Expected group {group_name} to be recreated, found {group_names}"
+    )
+
+    await redis_client.delete(stream_name)
+    await redis_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_partial_group_loss_redelivers_existing_messages():
+    """
+    When the consumer group is lost but the stream still has messages
+    (partial loss), the monitor should recreate the group with id="0"
+    so existing unprocessed messages are redelivered — not dropped.
+
+    With the old id="$" behaviour, the message published while the group
+    was missing would be permanently skipped.
+    """
+    redis_client = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+    test_id = uuid.uuid4().hex[:8]
+    channel_name = f"test-partial-{test_id}"
+    stream_name = f"eggai.{channel_name}"
+
+    transport = RedisTransport(group_monitor_interval_s=1.0)
+    agent = Agent(f"partial-agent-{test_id}", transport=transport)
+    channel = Channel(channel_name, transport=transport)
+
+    first_msg = asyncio.Event()
+    second_msg = asyncio.Event()
+
+    @agent.subscribe(channel=channel)
+    async def handler(message):
+        if first_msg.is_set():
+            second_msg.set()
+        else:
+            first_msg.set()
+
+    await agent.start()
+
+    # Publish a first message and wait for it to be consumed
+    await channel.publish({"type": "test", "data": "before", "test_id": test_id})
+    await asyncio.wait_for(first_msg.wait(), timeout=5.0)
+    assert first_msg.is_set()
+
+    # Resolve the actual group name used by the subscription
+    group_name = transport._stream_subscriptions[0].group
+
+    # Delete ONLY the consumer group, leaving the stream (with its entries) intact
+    await redis_client.xgroup_destroy(stream_name, group_name)
+
+    # Verify stream exists but group is gone
+    assert await redis_client.exists(stream_name)
+    groups = await redis_client.xinfo_groups(stream_name)
+    group_names = [
+        g["name"] if isinstance(g["name"], str) else g["name"].decode() for g in groups
+    ]
+    assert group_name not in group_names, "Group should have been destroyed"
+
+    # Publish via SDK while the group is missing — the message lands in the
+    # stream but no consumer group exists to deliver it yet.
+    await channel.publish(
+        {"type": "test", "data": "after-group-loss", "test_id": test_id}
+    )
+
+    # Wait for the monitor to recreate the group with id="0" and FastStream
+    # to recover (~4.5s recovery + monitor interval)
+    try:
+        await asyncio.wait_for(second_msg.wait(), timeout=15.0)
+    except asyncio.TimeoutError:
+        pass
+
+    await agent.stop()
+    await redis_client.delete(stream_name)
+    await redis_client.aclose()
+
+    # The key assertion: the message published while the group was missing
+    # must have been delivered. With id="$" it would be permanently dropped.
+    assert second_msg.is_set(), (
+        "Message published during partial group loss was not redelivered. "
+        "The group was likely recreated with id='$' instead of id='0'."
+    )


### PR DESCRIPTION
When Redis loses streams mid-life (restart without persistence, failover, memory eviction), FastStream's consume loop retries xreadgroup but never re-runs xgroup_create, causing an infinite NOGROUP error loop until pods are restarted.

This adds two recovery mechanisms:

1. A background stream group monitor in RedisTransport that periodically ensures all registered consumer groups exist via xgroup_create with MKSTREAM. The call is a no-op (BUSYGROUP) when groups already exist.

2. NOGROUP-aware error handling in PendingReclaimerManager that recreates the consumer group instead of logging an unhandled exception every reclaim cycle.

Closes #203

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD update
- [ ] Dependency update

## Related Issue

Fixes #203

## Changes Made

- Added `_monitor_stream_groups()` background task in `RedisTransport` that periodically calls `XGROUP CREATE` with `MKSTREAM` for all registered subscriptions
- Added NOGROUP error handling in `PendingReclaimerManager._run_loop()` that calls `_ensure_group()` to recreate consumer groups
- Added `_StreamGroupInfo` dataclass to track registered stream/group pairs
- Updated `sdk/CHANGELOG.md` with fix entry under `[Unreleased]`
- Added NOGROUP auto-recovery documentation to `docs/docs/sdk/redis-transport.md` and `sdk/README.md`

## Testing

- [x] Existing tests pass locally (`make test`)
- [x] Added new tests for new functionality

## Changelog

- [x] I have updated `sdk/CHANGELOG.md` under `[Unreleased]` section (required for code changes)

## Checklist

- [x] My code follows the project's code style (`make lint` passes)
- [x] My code is properly formatted (`make format` applied)
- [x] I have added/updated tests that prove my fix/feature works
- [x] I have added/updated documentation as needed
- [x] All tests pass locally
- [x] I have reviewed my own code
- [x] My changes generate no new warnings
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) standard