### PR TITLE
fix(redis): scope retry/dlq stream keys per-handler (#225)

### DIFF
--- a/docs/docs/sdk/redis-transport.md
+++ b/docs/docs/sdk/redis-transport.md
@@ -80,8 +80,9 @@ orders = Channel("orders", transport=transport)
 @agent.subscribe(channel=orders, retry_on_idle_ms=30_000)
 async def handle_order(message):
     # If this raises, the message stays in the PEL.
-    # After 30 s idle the SDK moves it to eggai.orders.retry
-    # and this same handler is called again.
+    # After 30 s idle the SDK moves it to a per-handler retry stream
+    # (e.g. eggai.orders.order-service-handle_order-1.retry) and this
+    # same handler is called again.
     await process_order(message)
 
 asyncio.run(agent.start())
@@ -90,10 +91,10 @@ asyncio.run(agent.start())
 The SDK automatically:
 
 1. Starts a background reclaimer that scans the PEL every 15 seconds (configurable via `retry_reclaim_interval_s`).
-2. Moves idle messages (older than `retry_on_idle_ms`) to a dedicated `{channel}.retry` stream.
+2. Moves idle messages (older than `retry_on_idle_ms`) to a dedicated **per-handler** `{channel}.{handler_suffix}.retry` stream. The per-handler suffix avoids one handler's failures being broadcast to other handlers on the same channel.
 3. Subscribes the **same handler** to the retry stream.
 4. Runs a second reclaimer on the retry stream that re-queues back to itself — no `.retry.retry` chain.
-5. After `max_retries` retry attempts (default 5), routes the message to a `{channel}.dlq` Dead Letter Queue instead of retrying again.
+5. After `max_retries` retry attempts (default 5), routes the message to a `{channel}.{handler_suffix}.dlq` Dead Letter Queue instead of retrying again.
 
 ### How It Works
 
@@ -102,8 +103,8 @@ Three Redis streams are involved:
 | Stream | Purpose |
 |---|---|
 | `eggai.orders` | Main stream — where messages arrive normally |
-| `eggai.orders.retry` | Retry stream — where failed messages get another chance |
-| `eggai.orders.dlq` | Dead Letter Queue — terminal; poison messages land here |
+| `eggai.orders.order-service-handle_order-1.retry` | Retry stream — where failed messages get another chance (per-handler; suffix is the handler id) |
+| `eggai.orders.order-service-handle_order-1.dlq` | Dead Letter Queue — terminal; poison messages land here (per-handler) |
 
 ```mermaid
 flowchart TD
@@ -114,8 +115,8 @@ flowchart TD
     FC -->|exception| PEL1["Main PEL\n(message stuck)"]
 
     PEL1 -->|"every 15 s: idle &gt; retry_on_idle_ms"| RC1["Reclaimer #1\nconsumer: …-reclaimer"]
-    RC1 -->|"_retry_count ≤ max_retries"| RS["Retry stream\neggai.orders.retry"]
-    RC1 -->|"_retry_count &gt; max_retries"| DLQ["Dead Letter Queue\neggai.orders.dlq\n(terminal)"]
+    RC1 -->|"_retry_count ≤ max_retries"| RS["Retry stream (per-handler)\neggai.orders.{handler}.retry"]
+    RC1 -->|"_retry_count &gt; max_retries"| DLQ["Dead Letter Queue (per-handler)\neggai.orders.{handler}.dlq\n(terminal)"]
     RC1 -->|XACK| DONE1[cleared from main PEL]
 
     RS -->|XREADGROUP &gt;| FC2["FastStream consumer\ngroup: …-retry\nsame handler"]
@@ -161,7 +162,7 @@ async def handle_order(message):
 
 ### Dead Letter Queue (DLQ)
 
-By default, messages that fail more than `max_retries` times (default 5) are routed to a `{channel}.dlq` stream. The DLQ is **terminal** — no automatic reclaimer watches it. Messages sit there until manually re-driven.
+By default, messages that fail more than `max_retries` times (default 5) are routed to a `{channel}.{handler_suffix}.dlq` stream (per-handler). The DLQ is **terminal** — no automatic reclaimer watches it. Messages sit there until manually re-driven.
 
 ```python
 @agent.subscribe(

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -10,6 +10,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Distributed tracing via OpenTelemetry**: Agents now propagate a shared `trace_id` across every message hop. Opt-in via `setup_tracing()`; zero-cost when not configured.
 
+### Fixed
+- **RedisTransport** (#225): Retry and DLQ stream keys are now per-handler
+  (`{channel}.{handler_suffix}.retry` / `.dlq`) instead of per-channel.
+  Previously, multiple handlers subscribing to the same channel with different
+  consumer groups shared a single `{channel}.retry` stream, so one handler's
+  reclaimed failure would be redelivered to **every** handler on that channel
+  via its auto-created `-retry` group. This caused work amplification (N
+  replays per nack, where N is the number of consumer groups on the channel)
+  and visible duplicate side-effects in downstream systems with non-idempotent
+  handlers.
+
+### Migration
+- **Breaking on-wire change.** Existing inflight messages in `{channel}.retry`
+  and `{channel}.dlq` streams will not be picked up by upgraded consumers —
+  they will continue to exist but new retries will land in the per-handler
+  streams. Drain the legacy streams before deploying, or `XADD` any pending
+  entries into the new per-handler keys.
+
 ## [0.2.14] - 2026-03-20
 
 ### Fixed

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -20,6 +20,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replays per nack, where N is the number of consumer groups on the channel)
   and visible duplicate side-effects in downstream systems with non-idempotent
   handlers.
+- **RedisTransport**: A permanently-unparseable ("poison") retry message is now
+  routed to the DLQ — or dropped with an error log when no DLQ is configured —
+  instead of being re-queued to the retry stream forever. Its retry count can
+  never be incremented, so it would previously livelock the per-handler retry
+  stream.
+- **RedisTransport**: The auto-created retry-stream subscriber now always reads
+  only new entries (`last_id=">"`) regardless of the main subscription's
+  `last_id`. Restarting with `last_id="0"` to replay the main backlog no longer
+  also replays the retry stream's history on every restart.
+- **RedisTransport**: A `RedisTransport` shared across multiple `Agent`s no
+  longer spawns duplicate consumer loops or orphans its consumer-group monitor
+  task when each agent calls `connect()`. Re-entrant `connect()` now starts only
+  not-yet-running subscribers and reuses the existing monitor.
+- **Tracing**: Retry-stream consumption now emits spans with the retry stream as
+  `messaging.destination` instead of the original channel, so retry attempts can
+  be observed separately from main-stream processing.
+- **RedisTransport**: `subscribe()` now rolls back the in-memory reclaimer configs
+  and stream-subscription entries it registered if retry-stream setup fails, so a
+  retried `start()` no longer accumulates orphaned registrations. Identical
+  stream-group subscriptions are also de-duplicated.
+
+### Changed
+- **RedisTransport**: `retry_on_idle_ms` now rejects `ack_policy=AckPolicy.ACK`
+  and `AckPolicy.ACK_FIRST` with a `ValueError`. Those acknowledge messages even
+  when the handler fails, emptying the PEL the reclaimer scans, which would
+  silently disable retries and the DLQ. Use the default `NACK_ON_ERROR`.
 
 ### Migration
 - **Breaking on-wire change.** Existing inflight messages in `{channel}.retry`

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -155,9 +155,10 @@ orders = Channel("orders", transport=transport)
 )
 async def handle_order(message):
     # If this raises, the message stays in the PEL.
-    # After 30s idle the reclaimer moves it to eggai.orders.retry
-    # and this same handler is called again.
-    # After 5 failed retries, the message is routed to eggai.orders.dlq.
+    # After 30s idle the reclaimer moves it to a per-handler retry stream
+    # (e.g. eggai.orders.order-service-handle_order-1.retry) and this same
+    # handler is called again. After 5 failed retries, the message is routed
+    # to the per-handler DLQ (eggai.orders.order-service-handle_order-1.dlq).
     await process_order(message)
 
 await agent.start()
@@ -165,10 +166,10 @@ await agent.start()
 
 The SDK automatically:
 1. Starts a background reclaimer that scans the PEL every 15 seconds (configurable via `retry_reclaim_interval_s`).
-2. Moves idle messages (older than `retry_on_idle_ms`) to a dedicated `{channel}.retry` stream.
+2. Moves idle messages (older than `retry_on_idle_ms`) to a dedicated **per-handler** `{channel}.{handler_suffix}.retry` stream. The per-handler suffix keeps one handler's failures from being broadcast to other handlers on the same channel.
 3. Subscribes the same handler to the retry stream.
 4. Runs a second reclaimer on the retry stream that re-queues back to itself (no `.retry.retry` chain).
-5. After `max_retries` retry attempts (default 5), routes the message to a `{channel}.dlq` Dead Letter Queue instead of retrying again.
+5. After `max_retries` retry attempts (default 5), routes the message to a per-handler `{channel}.{handler_suffix}.dlq` Dead Letter Queue instead of retrying again.
 
 **Delivery guarantee:** at-least-once. `XADD` and `XACK` are not atomic — a crash between
 them will re-deliver the message on the next cycle. Handlers must be **idempotent**.
@@ -180,8 +181,9 @@ Two fields are injected on retry delivery to aid deduplication:
 | `_original_message_id` | Redis stream ID of the original message |
 
 **Dead Letter Queue (DLQ):** Messages that exceed `max_retries` (default 5) are routed to
-`{channel}.dlq`. The DLQ is terminal — no automatic reclaimer. Set `max_retries=None` for
-unlimited retries. An optional `on_dlq` callback fires when a message lands in the DLQ.
+the per-handler `{channel}.{handler_suffix}.dlq`. The DLQ is terminal — no automatic
+reclaimer. Set `max_retries=None` for unlimited retries. An optional `on_dlq` callback
+fires when a message lands in the DLQ.
 
 **Automatic recovery from Redis stream loss (NOGROUP):**
 If Redis loses streams (restart without persistence, failover, memory eviction), the SDK
@@ -203,20 +205,20 @@ Main stream  (eggai.orders)
     │
     └── Reclaimer            (consumer: order-service-handle_order-1-reclaimer)
             every 15s: XPENDING → idle > 30s → XCLAIM
-            _retry_count ≤ max_retries → XADD orders.retry → XACK
-            _retry_count > max_retries → XADD orders.dlq   → XACK
+            _retry_count ≤ max_retries → XADD <retry stream> → XACK
+            _retry_count > max_retries → XADD <dlq stream>   → XACK
 
-Retry stream (eggai.orders.retry)
+Retry stream (eggai.orders.order-service-handle_order-1.retry)   ← per-handler
     │
     ├── FastStream consumer  (group: order-service-handle_order-1-retry)
     │       same handler — on exception → NACK → message stays in retry PEL
     │
     └── Reclaimer            (target: same retry stream — no .retry.retry chain)
             every 15s: XPENDING → idle > 30s → XCLAIM
-            _retry_count ≤ max_retries → XADD orders.retry → XACK
-            _retry_count > max_retries → XADD orders.dlq   → XACK
+            _retry_count ≤ max_retries → XADD <retry stream> → XACK
+            _retry_count > max_retries → XADD <dlq stream>   → XACK
 
-DLQ stream   (eggai.orders.dlq)
+DLQ stream   (eggai.orders.order-service-handle_order-1.dlq)      ← per-handler
         terminal — no reclaimer, manual re-drive only
 ```
 

--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -45,15 +45,17 @@ class ReclaimerConfig:
     stream: str  # full Redis key, e.g. "eggai.orders"
     group: str  # consumer group name (mirrors handler_id)
     consumer: str  # distinct from live consumer: f"{handler_id}-reclaimer"
-    retry_stream: str  # where to XADD rescued messages — never == stream
+    retry_stream: str  # full Redis key for reclaimed messages; equals `stream` for the retry reclaimer
     min_idle_ms: int
     interval_s: float
     max_retries: int | None = None  # None = unlimited retries (no DLQ)
-    dlq_stream: str | None = None  # e.g. "eggai.orders.dlq"
+    dlq_stream: str | None = (
+        None  # full key, e.g. "eggai.orders.order-service-handle_order-1.dlq"
+    )
     on_dlq: Callable | None = None  # async or sync callback(fields, msg_id, count)
 
 
-def _inject_retry_metadata(data: bytes, msg_id_str: str) -> tuple[bytes, int]:
+def _inject_retry_metadata(data: bytes, msg_id_str: str) -> tuple[bytes, int, bool]:
     """
     Inject _retry_count and _original_message_id into a FastStream binary stream
     entry's JSON body so the handler can read them for idempotency checks.
@@ -63,20 +65,22 @@ def _inject_retry_metadata(data: bytes, msg_id_str: str) -> tuple[bytes, int]:
       [2B num_headers]([2B key_len][key][2B val_len][val])*
       [JSON body bytes]
 
-    Returns a tuple of (modified __data__ bytes, new retry count).
-    On parse failure returns (original data, 0) so the message is never
-    mistakenly routed to the DLQ.
+    Returns a tuple of (modified __data__ bytes, new retry count, parsed_ok).
+    On parse failure returns (original data, 0, False): the caller treats an
+    unparseable envelope as a poison message (its retry count can never be
+    incremented, so re-queueing it would livelock the retry stream) and routes
+    it to the DLQ or drops it instead.
     """
     try:
         body_bytes, headers = BinaryMessageFormatV1.parse(data)
         body_dict = json.loads(body_bytes)
     except Exception:
         logger.warning(
-            "Failed to inject retry metadata for message %s; passing through unchanged",
+            "Failed to inject retry metadata for message %s; treating as poison",
             msg_id_str,
             exc_info=True,
         )
-        return data, 0
+        return data, 0, False
 
     new_count = int(body_dict.get("_retry_count", "0")) + 1
     body_dict["_retry_count"] = str(new_count)
@@ -101,7 +105,7 @@ def _inject_retry_metadata(data: bytes, msg_id_str: str) -> tuple[bytes, int]:
     writer.write_short(len(headers))  # 2B → len=20
     writer.write(headers_bytes)
     writer.write(new_body_bytes)
-    return writer.get_bytes(), new_count
+    return writer.get_bytes(), new_count, True
 
 
 class PendingReclaimerManager:
@@ -129,9 +133,14 @@ class PendingReclaimerManager:
         self._configs: dict[tuple[str, str, str], ReclaimerConfig] = {}
         self._tasks: dict[tuple[str, str, str], asyncio.Task] = {}
 
-    def add(self, config: ReclaimerConfig) -> None:
+    def add(self, config: ReclaimerConfig) -> tuple[str, str, str]:
         key = (config.stream, config.group, config.consumer)
         self._configs[key] = config
+        return key
+
+    def discard(self, key: tuple[str, str, str]) -> None:
+        """Remove a registered config by key — used to roll back a partial subscribe."""
+        self._configs.pop(key, None)
 
     async def start(self) -> None:
         """Start one background task per registered config. Safe to call again after stop."""
@@ -252,10 +261,37 @@ class PendingReclaimerManager:
             # next cycle (at-least-once). Use _original_message_id to deduplicate.
             data_key = b"__data__"
             new_count = 0
+            parsed_ok = True
             if data_key in fields:
-                fields[data_key], new_count = _inject_retry_metadata(
+                fields[data_key], new_count, parsed_ok = _inject_retry_metadata(
                     fields[data_key], msg_id_str
                 )
+
+            # Poison message: a permanently-unparseable envelope can never have its
+            # retry count incremented, so re-queueing it to the retry stream would
+            # livelock forever. Route it to the DLQ if configured, otherwise drop it
+            # (XACK) with a loud warning rather than spin on it indefinitely.
+            if not parsed_ok:
+                if config.dlq_stream is not None:
+                    await self._redis_client.xadd(config.dlq_stream, fields)
+                    await self._redis_client.xack(config.stream, config.group, msg_id)
+                    logger.warning(
+                        "Message %s has an unparseable envelope; moved to DLQ %s "
+                        "(retry count cannot be tracked)",
+                        msg_id_str,
+                        config.dlq_stream,
+                    )
+                    await self._invoke_on_dlq(
+                        config, fields, data_key, msg_id_str, new_count
+                    )
+                else:
+                    await self._redis_client.xack(config.stream, config.group, msg_id)
+                    logger.error(
+                        "Message %s has an unparseable envelope and no DLQ is "
+                        "configured; dropping it to avoid a retry-stream livelock",
+                        msg_id_str,
+                    )
+                continue
 
             # Route to DLQ if max retries exceeded, otherwise to retry stream.
             if (
@@ -271,27 +307,40 @@ class PendingReclaimerManager:
                     config.max_retries,
                     config.dlq_stream,
                 )
-                if config.on_dlq is not None:
-                    try:
-                        # Parse the binary envelope so the callback receives a
-                        # plain dict instead of raw bytes.
-                        parsed_msg: dict | bytes = fields
-                        if data_key in fields:
-                            try:
-                                body_bytes, _ = BinaryMessageFormatV1.parse(
-                                    fields[data_key]
-                                )
-                                parsed_msg = json.loads(body_bytes)
-                            except Exception:
-                                parsed_msg = fields
-                        result = config.on_dlq(parsed_msg, msg_id_str, new_count)
-                        if asyncio.iscoroutine(result):
-                            await result
-                    except Exception:
-                        logger.exception(
-                            "on_dlq callback failed for message %s", msg_id_str
-                        )
+                await self._invoke_on_dlq(
+                    config, fields, data_key, msg_id_str, new_count
+                )
             else:
                 await self._redis_client.xadd(config.retry_stream, fields)
                 await self._redis_client.xack(config.stream, config.group, msg_id)
                 logger.debug("Reclaimed %s → %s", msg_id_str, config.retry_stream)
+
+    async def _invoke_on_dlq(
+        self,
+        config: ReclaimerConfig,
+        fields: dict,
+        data_key: bytes,
+        msg_id_str: str,
+        new_count: int,
+    ) -> None:
+        """Invoke the optional on_dlq callback with a parsed message dict.
+
+        Parses the binary envelope so the callback receives a plain dict instead
+        of raw bytes; falls back to the raw fields if parsing fails. Callback
+        errors are logged but never block the DLQ write that already happened.
+        """
+        if config.on_dlq is None:
+            return
+        try:
+            parsed_msg: dict | bytes = fields
+            if data_key in fields:
+                try:
+                    body_bytes, _ = BinaryMessageFormatV1.parse(fields[data_key])
+                    parsed_msg = json.loads(body_bytes)
+                except Exception:
+                    parsed_msg = fields
+            result = config.on_dlq(parsed_msg, msg_id_str, new_count)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:
+            logger.exception("on_dlq callback failed for message %s", msg_id_str)

--- a/sdk/eggai/transport/redis.py
+++ b/sdk/eggai/transport/redis.py
@@ -116,7 +116,10 @@ class RedisTransport(Transport):
         self._redis_url = url
         self._running = False
         self._reclaimer_manager: PendingReclaimerManager | None = None
-        self._stream_subscriptions: list[_StreamGroupInfo] = []
+        # A set so repeated subscribe() calls with an identical (stream_key, group,
+        # group_create_id) collapse instead of accumulating duplicate XGROUP CREATE
+        # work in the monitor. _StreamGroupInfo is frozen/hashable.
+        self._stream_subscriptions: set[_StreamGroupInfo] = set()
         self._group_monitor_task: asyncio.Task | None = None
         self._group_monitor_interval_s: float = group_monitor_interval_s
 
@@ -130,11 +133,33 @@ class RedisTransport(Transport):
         # broker.start() creates all consumer groups (and streams via MKSTREAM).
         # Both the main and retry subscriptions were registered in subscribe() before
         # connect() is called, so all groups exist after this line.
-        await self.broker.start()
+        #
+        # A single RedisTransport may be shared across multiple Agents, and each
+        # Agent.start() calls connect(). FastStream's broker.start() restarts
+        # *every* registered subscriber on each call (it carries an upstream TODO
+        # to guard this), which would spawn a duplicate consume loop for handlers
+        # already running from an earlier connect(). Guard against that: do the
+        # full start the first time, then on subsequent connect()s only start the
+        # subscribers that aren't running yet (e.g. those a second Agent just
+        # registered). Falls back to the original full start() if FastStream ever
+        # stops exposing the `running` flags.
+        if not getattr(self.broker, "running", False):
+            await self.broker.start()
+        else:
+            await self.broker.connect()
+            for sub in self.broker.subscribers:
+                if not getattr(sub, "running", False):
+                    await sub.start()
         if self._reclaimer_manager is not None:
+            # start() is idempotent — it skips reclaimer tasks already running.
             await self._reclaimer_manager.start()
         self._running = True
-        if self._stream_subscriptions:
+        # Don't overwrite (and orphan) a monitor task still running from an
+        # earlier connect() on a shared transport — it already iterates the
+        # shared _stream_subscriptions set, which now includes the new groups.
+        if self._stream_subscriptions and (
+            self._group_monitor_task is None or self._group_monitor_task.done()
+        ):
             self._group_monitor_task = asyncio.create_task(
                 self._monitor_stream_groups(),
                 name="stream-group-monitor",
@@ -249,10 +274,16 @@ class RedisTransport(Transport):
         on_dlq = kwargs.pop("on_dlq", None)
         _internal_retry = kwargs.pop("_internal_retry", False)
 
-        # Only wrap the handler on the initial subscribe call, not on the
-        # internal recursive call for the retry stream — otherwise the retry
-        # handler gets double-wrapped, producing duplicate spans and corrupting
-        # the consumer group name (handler.__name__ becomes "traced_handler").
+        # The tracing wrapper binds the channel name into each span's
+        # messaging.destination, so we wrap per-stream: the main subscriber is
+        # wrapped with `channel` here, and (in the retry block below) the retry
+        # subscriber is wrapped with the retry stream key — otherwise retry-attempt
+        # spans would report the original channel and could not be dashboarded
+        # separately. We keep the unwrapped `original_handler` so the retry wrapper
+        # wraps it directly rather than nesting a second span on the channel
+        # wrapper. The recursive retry subscribe is marked _internal_retry=True and
+        # receives an already-wrapped handler, so it must not wrap again.
+        original_handler = handler
         if not _internal_retry:
             from eggai.tracing import make_tracing_wrapper
 
@@ -316,6 +347,21 @@ class RedisTransport(Transport):
         if max_retries is not None and max_retries < 1:
             raise ValueError("max_retries must be >= 1")
 
+        # SDK-managed retries need failed messages to stay in the PEL so the
+        # reclaimer can find them. ACK / ACK_FIRST acknowledge a message even when
+        # the handler raises, which empties the PEL and makes retries and the DLQ
+        # silently never fire. Reject that combination up front.
+        if retry_on_idle_ms is not None and kwargs.get("ack_policy") in (
+            AckPolicy.ACK,
+            AckPolicy.ACK_FIRST,
+        ):
+            raise ValueError(
+                "retry_on_idle_ms is incompatible with ack_policy=AckPolicy.ACK / "
+                "AckPolicy.ACK_FIRST: those acknowledge messages even when the "
+                "handler fails, so the PEL-based reclaimer never sees them and "
+                "retries/DLQ never trigger. Use the default NACK_ON_ERROR."
+            )
+
         # Default max_retries only applies when retry_on_idle_ms is set.
         if retry_on_idle_ms is None:
             max_retries = None
@@ -334,14 +380,15 @@ class RedisTransport(Transport):
 
         # Track the subscription so the background monitor can recreate the
         # consumer group if Redis loses the stream (restart, failover, eviction).
+        # Keep a reference so the retry block below can roll it back on failure.
+        main_sub_info = None
         if group:
-            self._stream_subscriptions.append(
-                _StreamGroupInfo(
-                    stream_key=self._get_stream_key(channel),
-                    group=group,
-                    group_create_id="$" if last_id == ">" else last_id,
-                )
+            main_sub_info = _StreamGroupInfo(
+                stream_key=self._get_stream_key(channel),
+                group=group,
+                group_create_id="$" if last_id == ">" else last_id,
             )
+            self._stream_subscriptions.add(main_sub_info)
 
         # Extract ack_policy or default to NACK_ON_ERROR for reliability
         # This ensures messages are NOT acknowledged when handlers raise exceptions,
@@ -360,61 +407,112 @@ class RedisTransport(Transport):
             # stream would broadcast one handler's failures to every other
             # handler on the channel via the auto-created `-retry` consumer
             # groups. See issue #225.
-            handler_suffix = (
-                handler_id if handler_id else f"{channel}-{handler.__name__}"
+            # `Agent`/`Channel` always inject a unique handler_id (via the
+            # HANDLERS_IDS counter), so the fallback only applies to callers that
+            # use transport.subscribe() directly. getattr guards objects without a
+            # __name__ (e.g. functools.partial), which would otherwise raise after
+            # the main-stream subscriber is already registered. Direct callers that
+            # run multiple distinct handlers on one channel with retry_on_idle_ms
+            # should pass a distinct handler_id per handler — otherwise same-named
+            # handlers (or lambdas) collapse to the same per-handler key. Derive
+            # the name from the original handler, not the tracing wrapper.
+            handler_name = (
+                getattr(original_handler, "__name__", None)
+                or type(original_handler).__name__
             )
+            handler_suffix = handler_id if handler_id else f"{channel}-{handler_name}"
             retry_stream = f"{channel}.{handler_suffix}.retry"
             dlq_stream = (
                 f"{channel}.{handler_suffix}.dlq" if max_retries is not None else None
             )
             retry_handler_id = f"{handler_suffix}-retry"
 
-            # Reclaimer for main stream: moves idle PEL entries to retry_stream
-            # (or to dlq_stream if max_retries is exceeded).
-            self._setup_reclaimer(
-                stream=channel,
-                group=group,
-                consumer=f"{group}-reclaimer",
-                retry_stream=retry_stream,
-                min_idle_ms=retry_on_idle_ms,
-                interval_s=retry_reclaim_interval_s,
-                max_retries=max_retries,
-                dlq_stream=dlq_stream,
-                on_dlq=on_dlq,
-            )
-
-            # Auto-subscribe the same handler to the retry stream.
-            # _internal_retry=True prevents infinite recursion and .retry.retry chains.
-            await self.subscribe(
-                retry_stream,
-                handler,
-                _internal_retry=True,
-                handler_id=retry_handler_id,
+            # Set up the retry machinery transactionally: if any step below (incl.
+            # the recursive retry subscribe) raises, roll back the in-memory
+            # registrations this call made so a retried Agent.start() does not
+            # accumulate orphaned reclaimer configs / stream-subscription entries.
+            # The FastStream broker subscriber(s) cannot be un-registered, but
+            # nothing is live until connect(), which never runs on failure.
+            added_reclaimer_keys: list[tuple[str, str, str]] = []
+            # The recursive subscribe below adds this entry (last_id=">" → "$").
+            retry_sub_info = _StreamGroupInfo(
+                stream_key=self._get_stream_key(retry_stream),
                 group=retry_handler_id,
-                consumer=retry_handler_id,
-                polling_interval=polling_interval,
-                batch=batch,
-                max_records=max_records,
-                last_id=last_id,
-                no_ack=no_ack,
-                ack_policy=ack_policy,
-                **kwargs,
+                group_create_id="$",
             )
+            try:
+                # Reclaimer for main stream: moves idle PEL entries to retry_stream
+                # (or to dlq_stream if max_retries is exceeded).
+                added_reclaimer_keys.append(
+                    self._setup_reclaimer(
+                        stream=channel,
+                        group=group,
+                        consumer=f"{group}-reclaimer",
+                        retry_stream=retry_stream,
+                        min_idle_ms=retry_on_idle_ms,
+                        interval_s=retry_reclaim_interval_s,
+                        max_retries=max_retries,
+                        dlq_stream=dlq_stream,
+                        on_dlq=on_dlq,
+                    )
+                )
 
-            # Reclaimer for retry stream: re-queues back to the same retry stream
-            # (avoids creating a .retry.retry chain). Routes to DLQ if max_retries
-            # is exceeded.
-            self._setup_reclaimer(
-                stream=retry_stream,
-                group=retry_handler_id,
-                consumer=f"{retry_handler_id}-reclaimer",
-                retry_stream=retry_stream,
-                min_idle_ms=retry_on_idle_ms,
-                interval_s=retry_reclaim_interval_s,
-                max_retries=max_retries,
-                dlq_stream=dlq_stream,
-                on_dlq=on_dlq,
-            )
+                # Wrap the *original* (unwrapped) handler with the retry stream as
+                # its tracing destination, so retry-attempt spans report the retry
+                # stream key rather than the original channel. Wrapping the original
+                # (not the channel-wrapped handler) keeps it to a single consumer
+                # span per retry.
+                from eggai.tracing import make_tracing_wrapper
+
+                retry_handler = make_tracing_wrapper(retry_stream, original_handler)
+
+                # Auto-subscribe the same handler to the retry stream.
+                # _internal_retry=True prevents infinite recursion and .retry.retry
+                # chains. last_id is pinned to ">" (new entries only) rather than
+                # forwarding the caller's last_id: an operator replaying the main
+                # stream (e.g. last_id="0") must not also replay the retry stream's
+                # history — the retry stream only ever holds freshly-reclaimed entries.
+                await self.subscribe(
+                    retry_stream,
+                    retry_handler,
+                    _internal_retry=True,
+                    handler_id=retry_handler_id,
+                    group=retry_handler_id,
+                    consumer=retry_handler_id,
+                    polling_interval=polling_interval,
+                    batch=batch,
+                    max_records=max_records,
+                    last_id=">",
+                    no_ack=no_ack,
+                    ack_policy=ack_policy,
+                    **kwargs,
+                )
+
+                # Reclaimer for retry stream: re-queues back to the same retry
+                # stream (avoids creating a .retry.retry chain). Routes to DLQ if
+                # max_retries is exceeded.
+                added_reclaimer_keys.append(
+                    self._setup_reclaimer(
+                        stream=retry_stream,
+                        group=retry_handler_id,
+                        consumer=f"{retry_handler_id}-reclaimer",
+                        retry_stream=retry_stream,
+                        min_idle_ms=retry_on_idle_ms,
+                        interval_s=retry_reclaim_interval_s,
+                        max_retries=max_retries,
+                        dlq_stream=dlq_stream,
+                        on_dlq=on_dlq,
+                    )
+                )
+            except Exception:
+                # Undo the reversible state this call registered, then re-raise.
+                if main_sub_info is not None:
+                    self._stream_subscriptions.discard(main_sub_info)
+                self._stream_subscriptions.discard(retry_sub_info)
+                if self._reclaimer_manager is not None:
+                    for key in added_reclaimer_keys:
+                        self._reclaimer_manager.discard(key)
+                raise
 
         return registered_handler
 
@@ -435,7 +533,9 @@ class RedisTransport(Transport):
         try:
             while self._running:
                 await asyncio.sleep(self._group_monitor_interval_s)
-                for info in self._stream_subscriptions:
+                # Iterate a snapshot: a concurrent subscribe() on a shared
+                # transport may mutate the set between awaits below.
+                for info in list(self._stream_subscriptions):
                     try:
                         stream_exists = await client.exists(info.stream_key)
                         create_id = "0" if stream_exists else info.group_create_id
@@ -476,10 +576,10 @@ class RedisTransport(Transport):
         max_retries: int | None = None,
         dlq_stream: str | None = None,
         on_dlq: Callable | None = None,
-    ) -> None:
+    ) -> tuple[str, str, str]:
         if self._reclaimer_manager is None:
             self._reclaimer_manager = PendingReclaimerManager(self._redis_url)
-        self._reclaimer_manager.add(
+        return self._reclaimer_manager.add(
             ReclaimerConfig(
                 stream=self._get_stream_key(stream),
                 group=group,

--- a/sdk/eggai/transport/redis.py
+++ b/sdk/eggai/transport/redis.py
@@ -208,7 +208,8 @@ class RedisTransport(Transport):
             min_idle_time (int, optional): Minimum idle time in milliseconds before a pending message can be auto-claimed
                 via FastStream's built-in XAUTOCLAIM. Mutually exclusive with retry_on_idle_ms.
             retry_on_idle_ms (int, optional): Enables SDK-managed PEL reclaiming. Messages stuck in the PEL longer than
-                this threshold are moved to a dedicated ``{channel}.retry`` stream and re-delivered to the same handler.
+                this threshold are moved to a dedicated ``{channel}.{handler_suffix}.retry`` stream (per-handler, so
+                concurrent handlers on the same channel do not see each other's retries) and re-delivered to the same handler.
                 Mutually exclusive with min_idle_time. Recommended: 30_000 (30 seconds).
                 Delivery is at-least-once — handlers must be idempotent. Injected fields _retry_count and
                 _original_message_id can be used for deduplication.
@@ -216,7 +217,7 @@ class RedisTransport(Transport):
             retry_reclaim_interval_s (float, optional): How often the reclaimer scans for stuck messages (default 15.0s).
                 Only used when retry_on_idle_ms is set.
             max_retries (int, optional): Maximum number of retry attempts before routing to the Dead Letter Queue
-                (``{channel}.dlq``). Default is 5 when retry_on_idle_ms is set. With max_retries=5, the handler is
+                (``{channel}.{handler_suffix}.dlq``). Default is 5 when retry_on_idle_ms is set. With max_retries=5, the handler is
                 called up to 6 times total (1 original + 5 retries). Set to None for unlimited retries (no DLQ).
                 Requires retry_on_idle_ms.
             on_dlq (Callable, optional): Callback invoked when a message is routed to the DLQ. Can be sync or async.
@@ -353,13 +354,20 @@ class RedisTransport(Transport):
         )(handler)
 
         if retry_on_idle_ms is not None and not _internal_retry:
-            retry_stream = f"{channel}.retry"
-            dlq_stream = f"{channel}.dlq" if max_retries is not None else None
-            retry_handler_id = (
-                f"{handler_id}-retry"
-                if handler_id
-                else f"{channel}-{handler.__name__}-retry"
+            # Per-handler retry/dlq stream keys: when multiple handlers
+            # subscribe to the same channel with different consumer groups,
+            # each gets its own retry/dlq streams. A single shared retry
+            # stream would broadcast one handler's failures to every other
+            # handler on the channel via the auto-created `-retry` consumer
+            # groups. See issue #225.
+            handler_suffix = (
+                handler_id if handler_id else f"{channel}-{handler.__name__}"
             )
+            retry_stream = f"{channel}.{handler_suffix}.retry"
+            dlq_stream = (
+                f"{channel}.{handler_suffix}.dlq" if max_retries is not None else None
+            )
+            retry_handler_id = f"{handler_suffix}-retry"
 
             # Reclaimer for main stream: moves idle PEL entries to retry_stream
             # (or to dlq_stream if max_retries is exceeded).

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -14,6 +14,7 @@ import uuid
 
 import pytest
 import redis.asyncio as redis
+from faststream import AckPolicy
 
 from eggai import Agent, Channel
 from eggai.transport import RedisTransport, eggai_set_default_transport
@@ -425,6 +426,10 @@ async def test_retry_does_not_fan_out_to_other_handlers():
 
     await agent_ok.stop()
     await agent_fail.stop()
+    # Clean up the per-handler retry/dlq streams + consumer groups this test
+    # created (deleting a stream also drops its consumer groups).
+    for key in await redis_client.keys(f"eggai.{channel_name}*"):
+        await redis_client.delete(key)
     await redis_client.aclose()
 
     assert len(ok_calls) == 1, (
@@ -437,6 +442,12 @@ async def test_retry_does_not_fan_out_to_other_handlers():
         f"handler_fail should have been called twice (1 original + 1 retry), "
         f"got {len(fail_calls)} calls."
     )
+    # Lock in payload identity, not just call counts.
+    assert ok_calls == ["x"], f"handler_ok saw unexpected payloads: {ok_calls}"
+    assert fail_calls == ["x", "x"], (
+        f"handler_fail should have seen payload 'x' on the original and the "
+        f"retry, got {fail_calls}"
+    )
 
 
 @pytest.mark.asyncio
@@ -446,7 +457,13 @@ async def test_retry_on_idle_ms_no_retry_retry_stream():
     The retry-stream reclaimer re-queues back to the same retry stream.
 
     Asserts:
-      - No stream named eggai.{channel}.retry.retry is ever created.
+      - The deep per-handler-nested ".retry.retry" key (which the _internal_retry
+        guard prevents) is never created.
+      - More broadly, no key under this channel ends with ".retry.retry" at all.
+        This also catches a regression where the retry reclaimer's republish
+        target gains a stray ".retry" suffix — that produces
+        eggai.{channel}.{group}.retry.retry, which does NOT embed the group
+        segment and so would slip past the nested-key check alone.
       - The retry handler is called multiple times (reclaimer keeps requeueing).
     """
     redis_client = redis.Redis(host="localhost", port=6379, decode_responses=True)
@@ -489,10 +506,20 @@ async def test_retry_on_idle_ms_no_retry_retry_stream():
     await agent.stop()
 
     retry_retry_exists = await redis_client.exists(retry_retry_stream)
+    # Broad guard: no stream under this channel may end with ".retry.retry",
+    # regardless of which segments precede it.
+    all_keys = await redis_client.keys(f"eggai.{channel_name}*")
+    retry_retry_keys = [k for k in all_keys if k.endswith(".retry.retry")]
+    # Clean up the streams + consumer groups this test created.
+    for key in all_keys:
+        await redis_client.delete(key)
     await redis_client.aclose()
 
     assert retry_retry_exists == 0, (
         f"A .retry.retry stream was created: {retry_retry_stream}"
+    )
+    assert not retry_retry_keys, (
+        f"Stream(s) ending in '.retry.retry' were created: {retry_retry_keys}"
     )
     assert call_count >= 3, (
         f"Expected handler to be called at least 3 times, got {call_count}"
@@ -549,6 +576,149 @@ async def test_retry_on_idle_ms_uses_prefixed_stream_keys():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("policy", [AckPolicy.ACK, AckPolicy.ACK_FIRST])
+async def test_retry_on_idle_ms_rejects_acking_ack_policies(policy):
+    """retry_on_idle_ms with an ack policy that ACKs on failure must raise.
+
+    ACK / ACK_FIRST acknowledge messages even when the handler fails, emptying
+    the PEL the reclaimer scans — so retries and the DLQ would silently never
+    fire. The subscription is rejected up front instead.
+    """
+    transport = RedisTransport()
+
+    async def handler(message):
+        return message
+
+    with pytest.raises(ValueError, match="ack_policy"):
+        await transport.subscribe(
+            "orders",
+            handler,
+            handler_id="orders-handler-1",
+            retry_on_idle_ms=500,
+            ack_policy=policy,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore:.*polling_interval.*:RuntimeWarning")
+async def test_retry_stream_pins_last_id_to_new_entries():
+    """The retry stream must consume only new entries, even when the operator
+    replays the main stream with last_id='0' (issue #225 review).
+
+    Otherwise restarting with last_id='0' to re-drain the main backlog would
+    also replay the retry stream's history on every restart.
+    """
+    transport = RedisTransport()
+
+    async def handler(message):
+        return message
+
+    await transport.subscribe(
+        "orders",
+        handler,
+        handler_id="orders-handler-1",
+        retry_on_idle_ms=500,
+        last_id="0",
+    )
+
+    subs = {s.stream_key: s for s in transport._stream_subscriptions}
+    # Main stream honours the operator's replay request...
+    assert subs["eggai.orders"].group_create_id == "0"
+    # ...but the retry stream is pinned to new entries regardless ("$" == ">").
+    assert subs["eggai.orders.orders-handler-1.retry"].group_create_id == "$"
+
+
+@pytest.mark.asyncio
+async def test_retry_stream_gets_its_own_tracing_destination(monkeypatch):
+    """The retry-stream subscriber must be traced with the retry stream as its
+    destination, not the original channel (issue #225 review).
+
+    The handler is tracing-wrapped per stream so retry-stream consumption can be
+    dashboarded separately from the main stream. Spying on make_tracing_wrapper
+    avoids needing OpenTelemetry installed.
+    """
+    import eggai.tracing as tracing_mod
+
+    wrapped_channels = []
+
+    def spy_wrapper(channel_name, handler):
+        wrapped_channels.append(channel_name)
+        return handler
+
+    monkeypatch.setattr(tracing_mod, "make_tracing_wrapper", spy_wrapper)
+
+    transport = RedisTransport()
+
+    async def handler(message):
+        return message
+
+    await transport.subscribe(
+        "orders",
+        handler,
+        handler_id="orders-handler-1",
+        retry_on_idle_ms=500,
+    )
+
+    # Main stream wrapped with the channel; retry stream wrapped with the
+    # per-handler retry key — and wrapped exactly once each (no double-wrap).
+    assert wrapped_channels == ["orders", "orders.orders-handler-1.retry"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_subscribe_dedups_stream_subscriptions():
+    """Repeated subscribe() with an identical (stream_key, group) collapses to a
+    single tracked subscription, so the monitor does not issue redundant
+    XGROUP CREATE per duplicate (issue #225 review).
+    """
+    transport = RedisTransport()
+
+    async def handler(message):
+        return message
+
+    await transport.subscribe("orders", handler, handler_id="orders-handler-1")
+    await transport.subscribe("orders", handler, handler_id="orders-handler-1")
+
+    orders_infos = [
+        s for s in transport._stream_subscriptions if s.stream_key == "eggai.orders"
+    ]
+    assert len(orders_infos) == 1
+
+
+@pytest.mark.asyncio
+async def test_subscribe_rolls_back_partial_registration_on_failure(monkeypatch):
+    """If retry-stream setup raises, subscribe() unwinds the in-memory reclaimer
+    configs and stream-subscription entries it registered, so a retried start()
+    does not accumulate orphans (issue #225 review).
+    """
+    transport = RedisTransport()
+    real_setup = transport._setup_reclaimer
+    calls = {"n": 0}
+
+    def flaky_setup(**kwargs):
+        calls["n"] += 1
+        # 2nd call = retry-stream reclaimer, after the recursive retry subscribe
+        # has already registered its own stream entry and broker subscriber.
+        if calls["n"] == 2:
+            raise RuntimeError("boom during retry setup")
+        return real_setup(**kwargs)
+
+    monkeypatch.setattr(transport, "_setup_reclaimer", flaky_setup)
+
+    async def handler(message):
+        return message
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await transport.subscribe(
+            "orders", handler, handler_id="orders-handler-1", retry_on_idle_ms=500
+        )
+
+    # Every reversible registration this call made is rolled back.
+    assert transport._stream_subscriptions == set()
+    if transport._reclaimer_manager is not None:
+        assert transport._reclaimer_manager._configs == {}
+
+
+@pytest.mark.asyncio
 async def test_retry_on_idle_ms_metadata():
     """
     Verify that _retry_count and _original_message_id are injected into the
@@ -595,14 +765,17 @@ async def test_retry_on_idle_ms_metadata():
 
 @pytest.mark.asyncio
 async def test_inject_retry_metadata_malformed_payload(caplog):
-    """_inject_retry_metadata logs a warning and returns (data, 0) for unparseable input."""
+    """_inject_retry_metadata logs a warning and reports parse failure for unparseable input."""
     from eggai.transport.pending_reclaimer import _inject_retry_metadata
 
     garbage = b"\x00\x01\x02not-valid-binary-format"
     with caplog.at_level(logging.WARNING, logger="eggai.transport.pending_reclaimer"):
-        result_data, result_count = _inject_retry_metadata(garbage, "0-1")
+        result_data, result_count, parsed_ok = _inject_retry_metadata(garbage, "0-1")
     assert result_data == garbage
     assert result_count == 0
+    # parsed_ok=False signals the caller to treat this as a poison message
+    # (route to DLQ / drop) instead of re-queueing it forever.
+    assert parsed_ok is False
     assert any("Failed to inject retry metadata" in r.message for r in caplog.records)
 
 
@@ -1057,8 +1230,9 @@ async def test_partial_group_loss_redelivers_existing_messages():
     await asyncio.wait_for(first_msg.wait(), timeout=5.0)
     assert first_msg.is_set()
 
-    # Resolve the actual group name used by the subscription
-    group_name = transport._stream_subscriptions[0].group
+    # Resolve the actual group name used by the subscription (single handler,
+    # no retry → exactly one tracked subscription).
+    group_name = next(iter(transport._stream_subscriptions)).group
 
     # Delete ONLY the consumer group, leaving the stream (with its entries) intact
     await redis_client.xgroup_destroy(stream_name, group_name)

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -309,7 +309,9 @@ async def test_retry_on_idle_ms_basic():
     test_id = uuid.uuid4().hex[:8]
     channel_name = f"test-retry-idle-{test_id}"
     stream_name = f"eggai.{channel_name}"
-    retry_stream_name = f"{stream_name}.retry"
+    # Per-handler retry stream key (issue #225).
+    group_main = f"retry-agent-{test_id}-handler-1"
+    retry_stream_name = f"{stream_name}.{group_main}.retry"
 
     transport = RedisTransport()
     agent = Agent(f"retry-agent-{test_id}", transport=transport)
@@ -344,7 +346,6 @@ async def test_retry_on_idle_ms_basic():
     await agent.stop()
 
     # Determine group names (mirrors agent.py handler_id format).
-    group_main = f"retry-agent-{test_id}-handler-1"
     group_retry = f"{group_main}-retry"
 
     def get_pending(info):
@@ -368,6 +369,77 @@ async def test_retry_on_idle_ms_basic():
 
 
 @pytest.mark.asyncio
+async def test_retry_does_not_fan_out_to_other_handlers():
+    """
+    Regression test for issue #225.
+
+    When two handlers subscribe to the same channel with different consumer
+    groups, a nack in one handler must NOT cause the message to be re-delivered
+    to the other handler that already acked it. The pre-fix behaviour was that
+    the reclaimer for the failing group XADDed the payload to a shared
+    ``{channel}.retry`` stream, and every other handler's auto-created
+    ``-retry`` consumer group on that same shared key received the entry.
+    """
+    redis_client = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+    test_id = uuid.uuid4().hex[:8]
+    channel_name = f"test-no-fanout-{test_id}"
+
+    transport = RedisTransport()
+    agent_ok = Agent(f"agent-ok-{test_id}", transport=transport)
+    agent_fail = Agent(f"agent-fail-{test_id}", transport=transport)
+    channel = Channel(channel_name, transport=transport)
+
+    ok_calls: list[str] = []
+    fail_calls: list[str] = []
+    fail_retry_done = asyncio.Event()
+
+    @agent_ok.subscribe(
+        channel=channel,
+        retry_on_idle_ms=300,
+        retry_reclaim_interval_s=0.5,
+    )
+    async def handler_ok(message):
+        ok_calls.append(message.get("data"))
+
+    @agent_fail.subscribe(
+        channel=channel,
+        retry_on_idle_ms=300,
+        retry_reclaim_interval_s=0.5,
+    )
+    async def handler_fail(message):
+        fail_calls.append(message.get("data"))
+        if len(fail_calls) == 1:
+            raise RuntimeError("first attempt fails")
+        fail_retry_done.set()
+
+    await agent_ok.start()
+    await agent_fail.start()
+
+    await channel.publish({"type": "test", "data": "x", "test_id": test_id})
+
+    # Wait for the failing handler to retry-succeed.
+    await asyncio.wait_for(fail_retry_done.wait(), timeout=10.0)
+    # Give any potential fan-out replay a chance to land in handler_ok.
+    await asyncio.sleep(2.0)
+
+    await agent_ok.stop()
+    await agent_fail.stop()
+    await redis_client.aclose()
+
+    assert len(ok_calls) == 1, (
+        f"handler_ok should have processed the message exactly once, got "
+        f"{len(ok_calls)} calls. Pre-fix behaviour: handler_fail's retry "
+        f"republish on the shared retry stream would have re-delivered the "
+        f"message to handler_ok via its `-retry` group."
+    )
+    assert len(fail_calls) == 2, (
+        f"handler_fail should have been called twice (1 original + 1 retry), "
+        f"got {len(fail_calls)} calls."
+    )
+
+
+@pytest.mark.asyncio
 async def test_retry_on_idle_ms_no_retry_retry_stream():
     """
     Persistent failure in the retry handler must NOT create a .retry.retry stream.
@@ -381,7 +453,12 @@ async def test_retry_on_idle_ms_no_retry_retry_stream():
 
     test_id = uuid.uuid4().hex[:8]
     channel_name = f"test-no-retry-retry-{test_id}"
-    retry_retry_stream = f"eggai.{channel_name}.retry.retry"
+    # Per-handler retry key (issue #225). The forbidden ".retry.retry" would
+    # nest under the new per-handler retry key, so check that path.
+    group_main = f"persistent-fail-agent-{test_id}-always_failing_handler-1"
+    retry_retry_stream = (
+        f"eggai.{channel_name}.{group_main}.retry.{group_main}-retry.retry"
+    )
 
     transport = RedisTransport()
     agent = Agent(f"persistent-fail-agent-{test_id}", transport=transport)
@@ -460,14 +537,15 @@ async def test_retry_on_idle_ms_uses_prefixed_stream_keys():
 
     assert len(configs) == 2
     assert configs[0].stream == "eggai.orders"
-    assert configs[0].retry_stream == "eggai.orders.retry"
+    # Per-handler retry/dlq keys (issue #225).
+    assert configs[0].retry_stream == "eggai.orders.orders-handler-1.retry"
     # Default max_retries=5 should set up DLQ stream
     assert configs[0].max_retries == 5
-    assert configs[0].dlq_stream == "eggai.orders.dlq"
-    assert configs[1].stream == "eggai.orders.retry"
-    assert configs[1].retry_stream == "eggai.orders.retry"
+    assert configs[0].dlq_stream == "eggai.orders.orders-handler-1.dlq"
+    assert configs[1].stream == "eggai.orders.orders-handler-1.retry"
+    assert configs[1].retry_stream == "eggai.orders.orders-handler-1.retry"
     assert configs[1].max_retries == 5
-    assert configs[1].dlq_stream == "eggai.orders.dlq"
+    assert configs[1].dlq_stream == "eggai.orders.orders-handler-1.dlq"
 
 
 @pytest.mark.asyncio
@@ -583,7 +661,9 @@ async def test_max_retries_routes_to_dlq():
 
     test_id = uuid.uuid4().hex[:8]
     channel_name = f"test-dlq-{test_id}"
-    dlq_stream_name = f"eggai.{channel_name}.dlq"
+    # Per-handler DLQ key (issue #225).
+    group_main = f"dlq-agent-{test_id}-always_fails-1"
+    dlq_stream_name = f"eggai.{channel_name}.{group_main}.dlq"
 
     transport = RedisTransport()
     agent = Agent(f"dlq-agent-{test_id}", transport=transport)
@@ -704,7 +784,9 @@ async def test_max_retries_none_disables_dlq():
 
     test_id = uuid.uuid4().hex[:8]
     channel_name = f"test-no-dlq-{test_id}"
-    dlq_stream_name = f"eggai.{channel_name}.dlq"
+    # Per-handler DLQ key (issue #225).
+    group_main = f"no-dlq-agent-{test_id}-always_fails-1"
+    dlq_stream_name = f"eggai.{channel_name}.{group_main}.dlq"
 
     transport = RedisTransport()
     agent = Agent(f"no-dlq-agent-{test_id}", transport=transport)
@@ -792,9 +874,10 @@ async def test_dlq_stream_naming():
     assert transport._reclaimer_manager is not None
 
     configs = list(transport._reclaimer_manager._configs.values())
+    expected_dlq = "eggai.orders.orders-handler-1.dlq"
     for config in configs:
-        assert config.dlq_stream == "eggai.orders.dlq", (
-            f"Expected dlq_stream='eggai.orders.dlq', got {config.dlq_stream}"
+        assert config.dlq_stream == expected_dlq, (
+            f"Expected dlq_stream={expected_dlq!r}, got {config.dlq_stream}"
         )
 
 
@@ -817,7 +900,8 @@ async def test_monitor_tracks_stream_subscriptions():
     assert len(transport._stream_subscriptions) == 2
     stream_keys = [s.stream_key for s in transport._stream_subscriptions]
     assert "eggai.orders" in stream_keys
-    assert "eggai.orders.retry" in stream_keys
+    # Per-handler retry stream key (issue #225).
+    assert "eggai.orders.orders-handler-1.retry" in stream_keys
 
     groups = [s.group for s in transport._stream_subscriptions]
     assert "orders-handler-1" in groups


### PR DESCRIPTION
When multiple handlers subscribe to the same Redis stream with different
consumer groups, a failure in one group's PEL is replayed to every
handler on the channel — not just the one that failed. The reclaimer
republishes to a single shared `{channel}.retry` key, and each handler
auto-subscribes to that key under its own `-retry` consumer group, so
every new `XADD` fans out to all of them. This breaks the isolation
users reasonably expect from independent consumer groups and amplifies
any nack into N replays (N = number of consumer groups on the channel).

This PR scopes the retry/dlq stream keys per-handler: each handler that
subscribes with `retry_on_idle_ms` now writes to its own
`{channel}.{handler_suffix}.retry` and (when `max_retries` is set)
`{channel}.{handler_suffix}.dlq` streams.

Closes #225

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD update
- [ ] Dependency update

## Related Issue

Fixes #225

## Changes Made

- Derive a per-handler `handler_suffix` from `handler_id` (or `{channel}-{handler.__name__}` fallback) in `RedisTransport.subscribe()`
- Retry stream key: `{channel}.{handler_suffix}.retry` (was `{channel}.retry`)
- DLQ stream key: `{channel}.{handler_suffix}.dlq` (was `{channel}.dlq`)
- Companion `-retry` consumer group on the retry stream is unchanged in shape — still `{handler_suffix}-retry`
- Second reclaimer (retry stream → retry stream) still uses `retry_stream=retry_stream`, so the "no `.retry.retry` chain" property is preserved
- Added regression test `test_retry_does_not_fan_out_to_other_handlers` — two agents on the same channel, one nacks, asserts the other is invoked exactly once
- Updated 7 existing tests that referenced the legacy literal stream names
- Updated `sdk/CHANGELOG.md` under `[Unreleased]` with `### Fixed` and `### Migration` sections
- Updated `docs/docs/sdk/redis-transport.md` (table, mermaid diagram, prose) to reflect the new per-handler key pattern

## Migration

Breaking on-wire change for the retry/dlq stream keys. Operators
upgrading mid-flight will:

- Still see existing `{channel}.retry` / `{channel}.dlq` streams in Redis after upgrade. They will no longer receive new entries.
- Need to drain those streams or manually `XADD` pending entries into the new per-handler keys before old data is dropped (e.g., on `XTRIM` or eviction).

Migration note also documented in `sdk/CHANGELOG.md`.

## Testing

- [x] Existing tests pass locally (`make test`)
- [x] Added new tests for new functionality

Local run: 22/22 redis-transport tests pass against a Redis 7 container,
including the new regression test.

## Changelog

- [x] I have updated `sdk/CHANGELOG.md` under `[Unreleased]` section (required for code changes)

## Checklist

- [x] My code follows the project's code style (`make lint` passes)
- [x] My code is properly formatted (`make format` applied)
- [x] I have added/updated tests that prove my fix/feature works
- [x] I have added/updated documentation as needed
- [x] All tests pass locally
- [x] I have reviewed my own code
- [x] My changes generate no new warnings
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) standard