### PR TITLE
feat(transport): exponential retry backoff for Redis SDK-managed retries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,21 @@ jobs:
 
     name: Test SDK (Python ${{ matrix.python-version }})
 
+    # Redis lets the Redis integration suite (tests/test_redis.py) actually run on
+    # CI. Without a reachable service, tests/conftest.py auto-skips every Redis
+    # test — so these were silently not exercised. The container is mapped to the
+    # localhost:6379 that conftest probes. (Kafka integration is not yet wired up.)
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **RedisTransport**: Exponential **retry backoff** for SDK-managed retries. New
+  `subscribe()` options `retry_backoff_multiplier` (default `1.0` = the previous
+  constant cadence), `retry_backoff_max_ms` (cap on the escalated delay), and
+  `retry_backoff_jitter` (spread retries across a worker fleet to avoid a
+  thundering herd). The PEL reclaimer now treats a failing message as due once it
+  has been idle for `retry_on_idle_ms * (retry_backoff_multiplier ** retry_count)`
+  (capped at `retry_backoff_max_ms`), so a repeatedly-failing message is retried
+  progressively less often (e.g. 30s → 60s → 120s …), giving an overloaded
+  downstream room to recover instead of being hammered on a fixed clock. Backoff
+  is opt-in and fully backward compatible: the default `multiplier=1.0` reproduces
+  the existing fixed `retry_on_idle_ms` spacing exactly.
+
 ## [0.3.1] - 2026-06-04
 
 ### Fixed

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -151,6 +151,9 @@ orders = Channel("orders", transport=transport)
     retry_on_idle_ms=30_000,          # reclaim after 30s idle (required to enable retry)
     max_retries=5,                    # route to DLQ after 5 retries (default: 5, None = unlimited)
     retry_reclaim_interval_s=15.0,    # PEL scan interval (default: 15.0)
+    retry_backoff_multiplier=2.0,     # exponential backoff between retries (default: 1.0 = constant)
+    retry_backoff_max_ms=900_000,     # cap the escalated delay (default: None = uncapped)
+    retry_backoff_jitter=0.2,         # add up to 20% on top of each delay to avoid a thundering herd (default: 0.0)
     on_dlq=None,                      # optional async/sync callback(fields, msg_id, count)
 )
 async def handle_order(message):
@@ -184,6 +187,21 @@ Two fields are injected on retry delivery to aid deduplication:
 the per-handler `{channel}.{handler_suffix}.dlq`. The DLQ is terminal — no automatic
 reclaimer. Set `max_retries=None` for unlimited retries. An optional `on_dlq` callback
 fires when a message lands in the DLQ.
+
+**Retry backoff:** By default retries fire at a constant cadence equal to
+`retry_on_idle_ms`. Set `retry_backoff_multiplier > 1.0` to back off exponentially: a
+message is treated as due for reclaim once it has been idle for
+`retry_on_idle_ms * (retry_backoff_multiplier ** _retry_count)`, capped at
+`retry_backoff_max_ms`. With a 30s base and multiplier `2.0` the attempts space out as
+30s → 60s → 120s → 240s …, giving an overloaded or recovering downstream room to breathe
+instead of being retried on a fixed clock. `retry_backoff_jitter` (a fraction in `[0, 1]`)
+adds a random `0..jitter` slice *on top of* each computed threshold so a fleet of workers
+that failed during the same outage don't come due in lockstep. Jitter is applied upward,
+never below `retry_on_idle_ms` — that base is a hard floor, since the reclaimer won't touch
+a message idle for less than it (it may be slow rather than stuck). Note the spread is only
+effective once `jitter × threshold` is comparable to `retry_reclaim_interval_s` (the scan
+cadence quantises smaller jitter away). Backoff is opt-in and backward compatible —
+the default `multiplier=1.0` preserves the constant `retry_on_idle_ms` spacing exactly.
 
 **Automatic recovery from Redis stream loss (NOGROUP):**
 If Redis loses streams (restart without persistence, failover, memory eviction), the SDK

--- a/sdk/eggai/agent.py
+++ b/sdk/eggai/agent.py
@@ -97,6 +97,31 @@ class Agent:
                     )
                 if max_retries is not None and max_retries < 1:
                     raise ValueError("max_retries must be >= 1")
+            _backoff_keys = (
+                "retry_backoff_multiplier",
+                "retry_backoff_max_ms",
+                "retry_backoff_jitter",
+            )
+            if any(k in kwargs for k in _backoff_keys):
+                if "retry_on_idle_ms" not in kwargs:
+                    raise ValueError(
+                        "retry_backoff_multiplier / retry_backoff_max_ms / "
+                        "retry_backoff_jitter require retry_on_idle_ms to be set."
+                    )
+                if kwargs.get("retry_backoff_multiplier", 1.0) < 1.0:
+                    raise ValueError(
+                        "retry_backoff_multiplier must be >= 1.0 (1.0 = constant "
+                        "cadence; values <1 would retry faster the more a message fails)."
+                    )
+                if not 0.0 <= kwargs.get("retry_backoff_jitter", 0.0) <= 1.0:
+                    raise ValueError("retry_backoff_jitter must be between 0.0 and 1.0")
+                _cap = kwargs.get("retry_backoff_max_ms")
+                if _cap is not None and _cap < kwargs["retry_on_idle_ms"]:
+                    raise ValueError(
+                        "retry_backoff_max_ms must be >= retry_on_idle_ms (the base "
+                        "idle threshold); a cap below the base would disable backoff "
+                        "entirely."
+                    )
             original_kwargs = kwargs.copy()
 
             # Extract plugin-specific kwargs dynamically and clean them from kwargs

--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import random
 from collections.abc import Callable
 from dataclasses import dataclass
 from struct import pack
@@ -56,6 +57,13 @@ class ReclaimerConfig:
     max_len: int | None = (
         None  # cap retry/DLQ stream length (XADD MAXLEN ~); None = unbounded
     )
+    # Exponential backoff between retry attempts. The reclaimer treats a PEL entry
+    # as "stale" once it has been idle for `min_idle_ms * (backoff_multiplier **
+    # retry_count)` (capped at backoff_max_ms). multiplier=1.0 reproduces the
+    # original constant cadence (stale at exactly min_idle_ms regardless of count).
+    backoff_multiplier: float = 1.0  # 1.0 = constant cadence (no escalation)
+    backoff_max_ms: int | None = None  # cap on the escalated threshold; None = uncapped
+    backoff_jitter: float = 0.0  # fraction in [0,1]; adds up to this share on top of the threshold at random
 
 
 def _inject_retry_metadata(data: bytes, msg_id_str: str) -> tuple[bytes, int, bool]:
@@ -232,11 +240,81 @@ class PendingReclaimerManager:
         else:
             await self._redis_client.xadd(stream, fields)
 
+    def _effective_idle_ms(self, config: ReclaimerConfig, retry_count: int) -> float:
+        """Idle time a message must accrue before this reclaim cycle treats it as stale.
+
+        With backoff_multiplier=1.0 this is just min_idle_ms (the original constant
+        cadence). Otherwise it grows geometrically with the message's retry count —
+        30s, 60s, 120s, … for multiplier=2 — so a repeatedly-failing message is
+        retried progressively less often, giving an overloaded downstream room to
+        recover instead of being hammered on a fixed clock. backoff_max_ms caps the
+        escalation.
+
+        backoff_jitter spreads a cohort of messages that failed together so they
+        don't all come due in the same instant (thundering herd). It is applied
+        *upward* — adding a random 0..jitter fraction on top of the threshold —
+        rather than downward, because min_idle_ms / retry_on_idle_ms is a hard floor:
+        the reclaim scan and XCLAIM both refuse to touch a PEL entry idle for less
+        than min_idle_ms (it may merely be slow, not stuck), so jitter that dipped
+        below the base would be invisible. Spreading upward keeps every reclaim at or
+        after the visibility timeout while still decorrelating the cohort. NOTE: the
+        spread is only effective once jitter * threshold is comparable to the scan
+        interval (retry_reclaim_interval_s, default 15s); smaller jitter is quantised
+        away by the scan cadence, which matters mostly at the lowest backoff levels.
+        """
+        # A large retry_count can make multiplier**retry_count exceed the max float
+        # and raise OverflowError. That's only realistically reachable when a cap is
+        # set (the cap bounds the interval, so retry_count climbs linearly over days
+        # for a never-acked poison message); uncapped, the interval grows so fast the
+        # count can't physically get there. Treat overflow as "infinitely far away"
+        # (+inf): with a cap, min() below clamps it to backoff_max_ms; uncapped, the
+        # entry simply isn't due this cycle. Either way the reclaimer never dies — an
+        # unguarded OverflowError here would abort the whole cycle and starve every
+        # other message on the stream.
+        try:
+            threshold = config.min_idle_ms * (config.backoff_multiplier**retry_count)
+        except OverflowError:
+            threshold = float("inf")
+        # Jitter before the cap so backoff_max_ms stays a hard ceiling on the result.
+        if config.backoff_jitter > 0.0 and threshold != float("inf"):
+            threshold *= 1.0 + random.uniform(0.0, config.backoff_jitter)
+        if config.backoff_max_ms is not None:
+            threshold = min(threshold, float(config.backoff_max_ms))
+        return threshold
+
+    async def _read_retry_count(self, stream: str, msg_id: Any) -> int:
+        """Read a pending entry's current ``_retry_count`` without disturbing it.
+
+        Uses XRANGE (non-destructive: unlike XCLAIM it neither resets the idle
+        timer nor transfers PEL ownership) so we can decide whether a message's
+        escalated backoff threshold has elapsed *before* committing to claim it.
+        Any failure (missing entry, unparseable envelope) falls back to 0 so the
+        message is treated with the base threshold rather than being skipped
+        forever.
+        """
+        try:
+            entries = await self._redis_client.xrange(stream, min=msg_id, max=msg_id)
+            if not entries:
+                return 0
+            _id, fields = entries[0]
+            data = fields.get(b"__data__")
+            if data is None:
+                return 0
+            body_bytes, _headers = BinaryMessageFormatV1.parse(data)
+            return int(json.loads(body_bytes).get("_retry_count", "0"))
+        except Exception:
+            return 0
+
     async def _reclaim_once(self, config: ReclaimerConfig) -> None:
         # --- Paginated XPENDING scan ---
         # A fixed count=100 only scans one page; with large or high-traffic PELs,
         # stale entries outside the first page would be delayed indefinitely.
-        stale_ids: list[Any] = []
+        #
+        # min_idle_ms is the *minimum* possible threshold (retry_count=0), so it
+        # works as a cheap pre-filter here regardless of backoff settings: anything
+        # below it can't be due yet under any retry count. When backoff is active we
+        # refine the survivors below with their per-message escalated threshold.
+        candidates: list[tuple[Any, int]] = []  # (message_id, idle_ms)
         cursor = "-"
         while True:
             page: list[dict] = await self._redis_client.xpending_range(
@@ -251,15 +329,31 @@ class PendingReclaimerManager:
             for entry in page:
                 idle = entry.get("time_since_delivered", 0)
                 if idle >= config.min_idle_ms:
-                    stale_ids.append(entry["message_id"])
+                    candidates.append((entry["message_id"], idle))
             if len(page) < 100:
                 break  # last page
             # Exclusive lower bound for next page — decode bytes to str if needed.
             last_id = page[-1]["message_id"]
             cursor = "(" + (last_id.decode() if isinstance(last_id, bytes) else last_id)
 
-        if not stale_ids:
+        if not candidates:
             return
+
+        # Fast path: constant cadence (no escalation, no jitter) keeps the original
+        # behaviour and skips the extra per-message XRANGE reads entirely.
+        backoff_active = config.backoff_multiplier != 1.0 or config.backoff_jitter > 0.0
+        if not backoff_active:
+            stale_ids: list[Any] = [msg_id for msg_id, _ in candidates]
+        else:
+            stale_ids = []
+            for msg_id, idle in candidates:
+                retry_count = await self._read_retry_count(config.stream, msg_id)
+                if idle >= self._effective_idle_ms(config, retry_count):
+                    stale_ids.append(msg_id)
+            # Messages not yet due stay in the PEL untouched; their idle keeps
+            # growing and a later cycle reclaims them once the threshold passes.
+            if not stale_ids:
+                return
 
         claimed: list[tuple[Any, dict]] = await self._redis_client.xclaim(
             name=config.stream,

--- a/sdk/eggai/transport/redis.py
+++ b/sdk/eggai/transport/redis.py
@@ -274,6 +274,21 @@ class RedisTransport(Transport):
                 Binary (non-UTF-8) field values are not supported.
             retry_reclaim_interval_s (float, optional): How often the reclaimer scans for stuck messages (default 15.0s).
                 Only used when retry_on_idle_ms is set.
+            retry_backoff_multiplier (float, optional): Exponential backoff factor applied between retry attempts
+                (default 1.0 = constant cadence, the original behaviour). A failing message is reclaimed once it has
+                been idle for ``retry_on_idle_ms * (retry_backoff_multiplier ** retry_count)``. With base 30s and
+                multiplier 2.0 the attempts space out as 30s → 60s → 120s → 240s …, so an overloaded downstream gets
+                progressively more room to recover instead of being retried on a fixed clock. Must be >= 1.0.
+                Requires retry_on_idle_ms.
+            retry_backoff_max_ms (int, optional): Upper bound on the escalated idle threshold so it doesn't grow without
+                limit (e.g. 900_000 caps backoff at 15 minutes). Default None (uncapped). Must be >= retry_on_idle_ms.
+                Requires retry_on_idle_ms.
+            retry_backoff_jitter (float, optional): Fraction in [0.0, 1.0] (default 0.0 = none). Adds a random
+                0..jitter share *on top of* each computed threshold, so a fleet of workers that all failed during the
+                same outage don't come due in lockstep (thundering herd) on recovery. Jitter is applied upward (never
+                below ``retry_on_idle_ms``) because that base is a hard floor — the reclaim scan won't touch an entry
+                idle for less than it. The spread is only effective once ``jitter * threshold`` is comparable to
+                ``retry_reclaim_interval_s`` (the scan cadence quantises smaller jitter away). Requires retry_on_idle_ms.
             max_retries (int, optional): Maximum number of retry attempts before routing to the Dead Letter Queue
                 (``{channel}.{handler_suffix}.dlq``). Default is 5 when retry_on_idle_ms is set. With max_retries=5, the handler is
                 called up to 6 times total (1 original + 5 retries). Set to None for unlimited retries (no DLQ).
@@ -305,6 +320,14 @@ class RedisTransport(Transport):
         _explicit_max_retries = "max_retries" in kwargs
         max_retries = kwargs.pop("max_retries", 5)
         on_dlq = kwargs.pop("on_dlq", None)
+        _explicit_backoff = (
+            "retry_backoff_multiplier" in kwargs
+            or "retry_backoff_max_ms" in kwargs
+            or "retry_backoff_jitter" in kwargs
+        )
+        retry_backoff_multiplier = kwargs.pop("retry_backoff_multiplier", 1.0)
+        retry_backoff_max_ms = kwargs.pop("retry_backoff_max_ms", None)
+        retry_backoff_jitter = kwargs.pop("retry_backoff_jitter", 0.0)
         _internal_retry = kwargs.pop("_internal_retry", False)
 
         # EggAI applies content filtering (filter_by_message) and typed-subscription
@@ -384,6 +407,31 @@ class RedisTransport(Transport):
 
         if max_retries is not None and max_retries < 1:
             raise ValueError("max_retries must be >= 1")
+
+        # Retry-backoff knobs only have meaning for SDK-managed retries, which are
+        # gated on retry_on_idle_ms. Reject them up front otherwise so a typo can't
+        # silently no-op (mirrors the max_retries guard above).
+        if _explicit_backoff and retry_on_idle_ms is None:
+            raise ValueError(
+                "retry_backoff_multiplier / retry_backoff_max_ms / "
+                "retry_backoff_jitter require retry_on_idle_ms to be set."
+            )
+        if retry_backoff_multiplier < 1.0:
+            raise ValueError(
+                "retry_backoff_multiplier must be >= 1.0 (1.0 = constant cadence; "
+                "values <1 would retry faster the more a message fails)."
+            )
+        if not 0.0 <= retry_backoff_jitter <= 1.0:
+            raise ValueError("retry_backoff_jitter must be between 0.0 and 1.0")
+        if (
+            retry_on_idle_ms is not None
+            and retry_backoff_max_ms is not None
+            and retry_backoff_max_ms < retry_on_idle_ms
+        ):
+            raise ValueError(
+                "retry_backoff_max_ms must be >= retry_on_idle_ms (the base idle "
+                "threshold); a cap below the base would disable backoff entirely."
+            )
 
         # SDK-managed retries need failed messages to stay in the PEL so the
         # reclaimer can find them. ACK / ACK_FIRST acknowledge a message even when
@@ -492,6 +540,9 @@ class RedisTransport(Transport):
                         max_retries=max_retries,
                         dlq_stream=dlq_stream,
                         on_dlq=on_dlq,
+                        backoff_multiplier=retry_backoff_multiplier,
+                        backoff_max_ms=retry_backoff_max_ms,
+                        backoff_jitter=retry_backoff_jitter,
                     )
                 )
 
@@ -551,6 +602,9 @@ class RedisTransport(Transport):
                         max_retries=max_retries,
                         dlq_stream=dlq_stream,
                         on_dlq=on_dlq,
+                        backoff_multiplier=retry_backoff_multiplier,
+                        backoff_max_ms=retry_backoff_max_ms,
+                        backoff_jitter=retry_backoff_jitter,
                     )
                 )
             except Exception:
@@ -625,6 +679,9 @@ class RedisTransport(Transport):
         max_retries: int | None = None,
         dlq_stream: str | None = None,
         on_dlq: Callable | None = None,
+        backoff_multiplier: float = 1.0,
+        backoff_max_ms: int | None = None,
+        backoff_jitter: float = 0.0,
     ) -> tuple[str, str, str]:
         if self._reclaimer_manager is None:
             self._reclaimer_manager = PendingReclaimerManager(self._redis_url)
@@ -640,6 +697,9 @@ class RedisTransport(Transport):
                 dlq_stream=self._get_stream_key(dlq_stream) if dlq_stream else None,
                 on_dlq=on_dlq,
                 max_len=self._retry_max_len,
+                backoff_multiplier=backoff_multiplier,
+                backoff_max_ms=backoff_max_ms,
+                backoff_jitter=backoff_jitter,
             )
         )
 

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -9,6 +9,7 @@ This test suite verifies:
 """
 
 import asyncio
+import json
 import logging
 import uuid
 
@@ -1623,3 +1624,297 @@ async def test_redis_invalid_payload_is_skipped_not_retried():
     await agent.stop()
 
     assert calls == [], "invalid-payload message should not reach the handler"
+
+
+# ---------------------------------------------------------------------------
+# Retry backoff: escalate the reclaimer's idle threshold by retry count so
+# repeatedly-failing messages are retried progressively less often.
+# ---------------------------------------------------------------------------
+
+
+async def _make_envelope(body: dict) -> bytes:
+    """Build a FastStream BinaryMessageFormatV1 envelope around a JSON body.
+
+    Used by the backoff tests to plant a stream entry with a known _retry_count.
+    """
+    from faststream.redis.parser.binary import BinaryMessageFormatV1
+
+    return await BinaryMessageFormatV1.encode(
+        message=body, reply_to=None, headers=None, correlation_id="test-cid"
+    )
+
+
+def _make_backoff_config(stream: str, retry_stream: str, **overrides):
+    from eggai.transport.pending_reclaimer import ReclaimerConfig
+
+    base = {
+        "stream": stream,
+        "group": "g",
+        "consumer": "g-reclaimer",
+        "retry_stream": retry_stream,
+        "min_idle_ms": 1000,
+        "interval_s": 60.0,
+        **overrides,
+    }
+    return ReclaimerConfig(**base)
+
+
+@pytest.mark.asyncio
+async def test_effective_idle_ms_escalates_and_caps():
+    """_effective_idle_ms grows geometrically with retry count and respects the cap."""
+    from eggai.transport.pending_reclaimer import PendingReclaimerManager
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    config = _make_backoff_config(
+        "s", "s.retry", backoff_multiplier=2.0, backoff_max_ms=5000
+    )
+
+    assert manager._effective_idle_ms(config, 0) == 1000
+    assert manager._effective_idle_ms(config, 1) == 2000
+    assert manager._effective_idle_ms(config, 2) == 4000
+    # 1000 * 2**3 = 8000, capped at 5000
+    assert manager._effective_idle_ms(config, 3) == 5000
+    assert manager._effective_idle_ms(config, 10) == 5000
+
+
+@pytest.mark.asyncio
+async def test_effective_idle_ms_huge_retry_count_does_not_overflow():
+    """A retry_count large enough to overflow multiplier**retry_count must not raise.
+
+    Capped: clamps to backoff_max_ms (the float overflow becomes +inf, then min()
+    pins it to the cap). Uncapped: returns +inf so the entry just isn't due — but
+    crucially the reclaimer cycle never dies on an OverflowError, which would
+    otherwise starve every other message on the stream.
+    """
+    from eggai.transport.pending_reclaimer import PendingReclaimerManager
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+
+    # 2.0 ** 5000 overflows the max float (~1.8e308) several times over.
+    capped = _make_backoff_config(
+        "s", "s.retry", backoff_multiplier=2.0, backoff_max_ms=900_000
+    )
+    assert manager._effective_idle_ms(capped, 5000) == 900_000
+
+    uncapped = _make_backoff_config("s", "s.retry", backoff_multiplier=2.0)
+    assert manager._effective_idle_ms(uncapped, 5000) == float("inf")
+
+    # Jitter must not turn +inf into a NaN or raise.
+    jittered = _make_backoff_config(
+        "s", "s.retry", backoff_multiplier=2.0, backoff_jitter=0.5
+    )
+    assert manager._effective_idle_ms(jittered, 5000) == float("inf")
+
+
+@pytest.mark.asyncio
+async def test_effective_idle_ms_constant_when_multiplier_one():
+    """multiplier=1.0 reproduces the original constant cadence at every count."""
+    from eggai.transport.pending_reclaimer import PendingReclaimerManager
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    config = _make_backoff_config("s", "s.retry")  # multiplier defaults to 1.0
+    for count in range(5):
+        assert manager._effective_idle_ms(config, count) == 1000
+
+
+@pytest.mark.asyncio
+async def test_effective_idle_ms_jitter_spreads_upward_above_base():
+    """Jitter spreads *upward* — [base, base*(1+jitter)] — never below the base floor.
+
+    Downward jitter would be invisible: the reclaim scan and XCLAIM both floor at
+    min_idle_ms, so a threshold below the base is never observable. Spreading upward
+    keeps every reclaim at/after the visibility timeout while still decorrelating a
+    cohort. This is the constant-cadence (multiplier=1.0) case — the one where the
+    old downward jitter was a complete no-op.
+    """
+    from eggai.transport.pending_reclaimer import PendingReclaimerManager
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    config = _make_backoff_config("s", "s.retry", backoff_jitter=0.5)  # multiplier 1.0
+    samples = [manager._effective_idle_ms(config, 0) for _ in range(200)]
+    # Upward only: never below the base floor (1000), never above base*(1+jitter).
+    assert all(1000.0 <= s <= 1500.0 for s in samples), (
+        f"jitter out of bounds: min={min(samples)}, max={max(samples)}"
+    )
+    # Genuinely observable past the base floor (the bug this guards against), and
+    # actually spread rather than constant.
+    assert max(samples) > 1000.0
+    assert len(set(samples)) > 1
+
+
+@pytest.mark.asyncio
+async def test_effective_idle_ms_jitter_stays_under_cap():
+    """Jitter is applied before the cap, so backoff_max_ms remains a hard ceiling."""
+    from eggai.transport.pending_reclaimer import PendingReclaimerManager
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    # base*mult^count = 1000*2**3 = 8000; jitter would push to 12000, but the cap
+    # pins it at 5000 regardless.
+    config = _make_backoff_config(
+        "s", "s.retry", backoff_multiplier=2.0, backoff_max_ms=5000, backoff_jitter=0.5
+    )
+    samples = [manager._effective_idle_ms(config, 3) for _ in range(50)]
+    assert all(s == 5000 for s in samples), f"cap breached: max={max(samples)}"
+
+
+@pytest.mark.asyncio
+async def test_backoff_validation():
+    """retry_backoff_* knobs reject invalid values and require retry_on_idle_ms."""
+    transport = RedisTransport()
+    agent = Agent("backoff-val-agent", transport=transport)
+    channel = Channel("test-backoff-val", transport=transport)
+
+    with pytest.raises(ValueError, match="require retry_on_idle_ms"):
+
+        @agent.subscribe(channel=channel, retry_backoff_multiplier=2.0)
+        async def h_no_idle(message):
+            pass
+
+    with pytest.raises(ValueError, match="retry_backoff_multiplier must be >= 1.0"):
+
+        @agent.subscribe(
+            channel=channel, retry_on_idle_ms=500, retry_backoff_multiplier=0.5
+        )
+        async def h_low_mult(message):
+            pass
+
+    with pytest.raises(ValueError, match="retry_backoff_jitter must be between"):
+
+        @agent.subscribe(
+            channel=channel, retry_on_idle_ms=500, retry_backoff_jitter=1.5
+        )
+        async def h_bad_jitter(message):
+            pass
+
+    with pytest.raises(ValueError, match="retry_backoff_max_ms must be >="):
+
+        @agent.subscribe(
+            channel=channel, retry_on_idle_ms=500, retry_backoff_max_ms=100
+        )
+        async def h_low_cap(message):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_backoff_params_propagate_to_reclaimer_configs():
+    """Backoff kwargs flow into every reclaimer config (main + retry streams)."""
+    transport = RedisTransport()
+
+    async def handler(message):
+        return message
+
+    await transport.subscribe(
+        "orders",
+        handler,
+        handler_id="orders-backoff-1",
+        retry_on_idle_ms=500,
+        retry_backoff_multiplier=3.0,
+        retry_backoff_max_ms=60_000,
+        retry_backoff_jitter=0.2,
+    )
+
+    configs = list(transport._reclaimer_manager._configs.values())
+    assert len(configs) == 2, "expected a main-stream and a retry-stream reclaimer"
+    for config in configs:
+        assert config.backoff_multiplier == 3.0
+        assert config.backoff_max_ms == 60_000
+        assert config.backoff_jitter == 0.2
+
+
+async def _deliver_to_pel(client, stream, group, consumer, envelope):
+    """XADD an envelope, create the group, and XREADGROUP it so it lands in the PEL.
+
+    Returns the message id (bytes) of the delivered entry.
+    """
+    await client.xadd(stream, {b"__data__": envelope})
+    await client.xgroup_create(name=stream, groupname=group, id="0", mkstream=True)
+    delivered = await client.xreadgroup(
+        groupname=group, consumername=consumer, streams={stream: ">"}, count=10
+    )
+    # delivered: [[stream, [(id, fields), ...]]]
+    return delivered[0][1][0][0]
+
+
+@pytest.mark.asyncio
+async def test_backoff_skips_high_retry_count_message_not_yet_due():
+    """A high-_retry_count entry whose escalated threshold hasn't elapsed is left
+    in the PEL — not prematurely moved to the retry stream."""
+    from eggai.transport.pending_reclaimer import PendingReclaimerManager
+
+    test_id = uuid.uuid4().hex[:8]
+    stream = f"eggai.backoff-skip-{test_id}"
+    retry_stream = f"{stream}.retry"
+    group = f"g-{test_id}"
+
+    client = redis.Redis(host="localhost", port=6379, decode_responses=False)
+    # _retry_count=3 with multiplier=10, base=100ms → threshold = 100 * 10**3 = 100s.
+    envelope = await _make_envelope({"type": "t", "_retry_count": "3", "id": test_id})
+    await _deliver_to_pel(client, stream, group, f"{group}-live", envelope)
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    manager._redis_client = redis.Redis(
+        host="localhost", port=6379, decode_responses=False
+    )
+    config = _make_backoff_config(
+        stream, retry_stream, group=group, min_idle_ms=100, backoff_multiplier=10.0
+    )
+
+    # Idle is now ~0ms; wait past the BASE threshold (100ms) but nowhere near the
+    # escalated 100s threshold for _retry_count=3.
+    await asyncio.sleep(0.3)
+    await manager._reclaim_once(config)
+
+    # Message must still be pending on the original stream, retry stream empty.
+    pending = await client.xpending(stream, group)
+    assert pending["pending"] == 1, (
+        "high-retry-count message should not be reclaimed yet"
+    )
+    # xlen returns 0 for a never-created stream, so this covers "retry stream empty".
+    assert await client.xlen(retry_stream) == 0
+
+    await manager._redis_client.aclose()
+    await client.delete(stream, retry_stream)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_backoff_reclaims_message_once_threshold_elapsed():
+    """A low-_retry_count entry past its (small) threshold is reclaimed normally."""
+    from eggai.transport.pending_reclaimer import PendingReclaimerManager
+
+    test_id = uuid.uuid4().hex[:8]
+    stream = f"eggai.backoff-due-{test_id}"
+    retry_stream = f"{stream}.retry"
+    group = f"g-{test_id}"
+
+    client = redis.Redis(host="localhost", port=6379, decode_responses=False)
+    # _retry_count=0 with multiplier=10, base=100ms → threshold = 100ms.
+    envelope = await _make_envelope({"type": "t", "_retry_count": "0", "id": test_id})
+    await _deliver_to_pel(client, stream, group, f"{group}-live", envelope)
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    manager._redis_client = redis.Redis(
+        host="localhost", port=6379, decode_responses=False
+    )
+    config = _make_backoff_config(
+        stream, retry_stream, group=group, min_idle_ms=100, backoff_multiplier=10.0
+    )
+
+    await asyncio.sleep(0.3)  # idle ~300ms >= 100ms threshold for _retry_count=0
+    await manager._reclaim_once(config)
+
+    # Reclaimed: original PEL drained, message moved to the retry stream with
+    # _retry_count bumped to 1.
+    pending = await client.xpending(stream, group)
+    assert pending["pending"] == 0, "due message should have been reclaimed"
+    assert await client.xlen(retry_stream) == 1
+
+    entries = await client.xrange(retry_stream)
+    from faststream.redis.parser.binary import BinaryMessageFormatV1
+
+    body_bytes, _ = BinaryMessageFormatV1.parse(entries[0][1][b"__data__"])
+    assert int(json.loads(body_bytes)["_retry_count"]) == 1
+
+    await manager._redis_client.aclose()
+    await client.delete(stream, retry_stream)
+    await client.aclose()


### PR DESCRIPTION
- **Add:** opt-in exponential backoff between SDK-managed retries on the Redis transport. A failing message is reclaimed once it's been idle for `retry_on_idle_ms × (multiplier ** retry_count)`, capped at `retry_backoff_max_ms`, so a repeatedly-failing message backs off (30s → 60s → 120s …) instead of being retried on a fixed clock — giving an overloaded  ownstream room to recover.

- **CI:** added a Redis service to the test job so the Redis integration suite
  (45 tests) actually runs on every PR — it was being silently skipped.