### PR TITLE
Fix calling convention mismatch

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.3] - 2026-08-19
-
 ### Fixed
 - **Tracing wrapper handler dispatch**: `traced_handler` now accepts `*args`/`**kwargs`,
   fixing `TypeError: got an unexpected keyword argument` for handlers whose message

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-08-19
+
+### Fixed
+- **Tracing wrapper handler dispatch**: `traced_handler` now accepts `*args`/`**kwargs`,
+  fixing `TypeError: got an unexpected keyword argument` for handlers whose message
+  parameter isn't named `message` under FastStream 0.7's keyword-based dispatch.
+
 ## [0.3.2] - 2026-06-15
 
 ### Fixed

--- a/sdk/eggai/tracing.py
+++ b/sdk/eggai/tracing.py
@@ -175,7 +175,14 @@ def make_tracing_wrapper(channel_name: str, handler: Callable) -> Callable:
         return handler
 
     @functools.wraps(handler)
-    async def traced_handler(message):
+    async def traced_handler(*args, **kwargs):
+        # functools.wraps sets __wrapped__, and inspect.signature() follows it,
+        # so FastStream/fast_depends builds its call model from the *user's*
+        # handler signature, not ours -- the parameter name it passes is
+        # whatever the user named it. FastStream 0.6 called positionally;
+        # 0.7 calls by keyword. Accept either and forward verbatim.
+        message = args[0] if args else next(iter(kwargs.values()), None)
+
         traceparent = (
             message.get("traceparent")
             if isinstance(message, dict)


### PR DESCRIPTION
# Description

traced_handler in eggai/tracing.py uses functools.wraps, which sets __wrapped__. inspect.signature() follows __wrapped__, so FastStream/fast_depends builds its call model from the user's handler signature (e.g. msg: TracedMessage) while the wrapper only accepts a parameter named message. FastStream 0.6 invoked handlers positionally, which masked the mismatch; 0.7 invokes by keyword, so any handler whose parameter isn't literally named message now fails at dispatch:

TypeError: handle_other_messages() got an unexpected keyword argument 'msg'

The wrapper now accepts *args, **kwargs and forwards them verbatim, so it works under either calling convention and for any parameter name.

Affects only the tracing-enabled, no-filter-options path: when filter_by_message/data_type are supplied, wrap_handler_with_filters returns a wrapper that deliberately advertises its own (message) signature, so tracing wraps that instead and the names line up by accident. middleware_utils.py is intentionally left unchanged — its wrappers must stay signature-opaque so FastStream hands them the raw dict.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD update
- [ ] Dependency update

## Changes Made

- traced_handler now takes *args, **kwargs and forwards them unchanged to the wrapped handler
- Message argument resolved from either positional or keyword form for traceparent extraction and span attributes
- Added comment explaining the __wrapped__ interaction and why this wrapper is signature-transparent while the filter wrappers are deliberately not

## Changelog

- [x] I have updated `sdk/CHANGELOG.md` under `[Unreleased]` section (required for code changes)

## Additional Notes
The SDK declares faststream[kafka,redis] (>=0.6,<0.8) but the transport code has no version branching — it targets 0.7's API unconditionally (see the note in middleware_utils.py about removed subscriber middlewares).