### PR TITLE
Fix/tracing forward handler args

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Forward original args/kwargs to wrapped handler**: 0.3.3 changed traced_handler's signature to *args/**kwargs but still
+  called handler(message) positionally
+
 ## [0.3.3] - 2026-08-19
 
 ### Fixed

--- a/sdk/eggai/tracing.py
+++ b/sdk/eggai/tracing.py
@@ -191,7 +191,7 @@ def make_tracing_wrapper(channel_name: str, handler: Callable) -> Callable:
         with _backend.start_consumer_span(channel_name, traceparent) as span:
             _set_span_attrs(span, channel_name, message, "process")
             try:
-                return await handler(message)
+                return await handler(*args, **kwargs)
             except Exception as exc:
                 span.record_exception(exc)
                 span.set_error_status(str(exc))


### PR DESCRIPTION
# Description

0.3.3 changed traced_handler's signature to *args/**kwargs but still
called handler(message) positionally. Handlers that only accept their
message by keyword then failed with "missing 1 required positional
argument". Forward the original args and kwargs unchanged; `message`
remains for span attributes only.

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD update
- [ ] Dependency update

## Changelog

- [x] I have updated `sdk/CHANGELOG.md` under `[Unreleased]` section (required for code changes)

