### PR TITLE
Make BaseMessage.data required (typed subclasses silently accept a missing payload)

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING: `BaseMessage.data` is now required.** The generic base previously
+  declared `data: TData = Field(default_factory=dict)`. Pydantic does not
+  validate defaults, so an envelope missing `data` validated cleanly on *any*
+  typed subclass (`BaseMessage[Order]`) with `data` as a plain `{}` — the
+  handler then crashed on first attribute access, and under `NACK_ON_ERROR`
+  that single malformed message wedged the subscription. A missing or malformed
+  payload now fails validation, which typed subscriptions
+  (`wrap_handler_with_filters`) already treat as "not ours: skip and ack".
+  The concrete `Message` keeps its `{}` default, where the annotation really is
+  a dict. Migration: construct payload-less envelopes with `Message` (or pass
+  `data=` explicitly).
+
 ## [0.3.4] - 2026-08-19
 
 ### Fixed

--- a/sdk/eggai/schemas.py
+++ b/sdk/eggai/schemas.py
@@ -20,8 +20,10 @@ class BaseMessage(BaseModel, Generic[TData]):
     metadata and context as CloudEvents-compliant extension attributes.
 
     The model is generic so that you can specify custom Pydantic models
-    for data, the application-specific event payload.
-    By default, if no custom model is provided, data is a dictionary.
+    for data, the application-specific event payload. ``data`` is required:
+    a typed subclass (``BaseMessage[Order]``) then rejects envelopes whose
+    payload is missing or malformed instead of silently defaulting. For a
+    plain dict payload with an empty default, use :class:`Message`.
 
     Fields:
         specversion (str): CloudEvents version (always "1.0").
@@ -32,7 +34,7 @@ class BaseMessage(BaseModel, Generic[TData]):
         time (Optional[datetime]): Timestamp of event creation.
         datacontenttype (Optional[str]): Media type of the event data.
         dataschema (Optional[str]): URI of the schema that `data` adheres to.
-        data (TData): Application-specific event payload.
+        data (TData): Application-specific event payload (required).
     """
 
     specversion: str = Field(
@@ -65,8 +67,14 @@ class BaseMessage(BaseModel, Generic[TData]):
         default=None,
         description="W3C traceparent for distributed trace context propagation.",
     )
+    # No default here: pydantic does not validate defaults, so a dict default on a
+    # field typed TData would hand every typed subclass a plain `{}` whenever an
+    # envelope omits `data` — the subclass's annotation says Order, the runtime
+    # value is a dict, and the handler crashes on first attribute access. Requiring
+    # the field turns that envelope into a ValidationError, which the transports'
+    # typed subscriptions already treat as "not ours: skip and ack".
     data: TData = Field(
-        default_factory=dict,
+        ...,
         description="Event payload containing application-specific data.",
     )
 
@@ -77,4 +85,8 @@ class Message(BaseMessage[dict[str, Any]]):
     Concrete Message model with `data` defaulting to dict.
     """
 
-    pass
+    # The dict default lives here, where the annotation actually is a dict.
+    data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Event payload containing application-specific data.",
+    )

--- a/sdk/tests/test_middleware_utils.py
+++ b/sdk/tests/test_middleware_utils.py
@@ -196,3 +196,39 @@ async def test_filter_by_data_narrows_typed_messages():
     await wrapped(_order_msg(order_id=2, status="shipped"))
 
     assert seen == [2]
+
+
+@pytest.mark.asyncio
+async def test_data_type_skips_envelope_with_missing_data():
+    """An envelope of the right type but with no ``data`` key must be skipped.
+
+    Regression test: ``data`` used to default to ``{}`` on the generic base and
+    pydantic does not validate defaults, so this envelope validated cleanly and
+    reached the handler with ``data`` as a plain dict — crashing on the first
+    ``order.data.<attr>`` access and, under NACK_ON_ERROR, wedging the stream on
+    a single malformed message.
+    """
+    seen = []
+
+    async def handler(order):
+        seen.append(order)
+
+    wrapped = wrap_handler_with_filters(handler, data_type=OrderMessage)
+    envelope = _order_msg()
+    del envelope["data"]
+
+    assert await wrapped(envelope) is None  # skipped -> acked, not retried
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_data_type_skips_envelope_with_malformed_data():
+    seen = []
+
+    async def handler(order):
+        seen.append(order)
+
+    wrapped = wrap_handler_with_filters(handler, data_type=OrderMessage)
+    await wrapped(_order_msg(data={"unexpected": "shape"}))
+
+    assert seen == []

--- a/sdk/tests/test_schemas.py
+++ b/sdk/tests/test_schemas.py
@@ -1,0 +1,47 @@
+"""Contract tests for the CloudEvents envelope models."""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from eggai.schemas import BaseMessage, Message
+
+
+class Order(BaseModel):
+    order_id: int
+
+
+class OrderMessage(BaseMessage[Order]):
+    type: str = "OrderMessage"
+
+
+def test_typed_subclass_requires_data():
+    # Without this, a missing payload silently became `data == {}` (pydantic
+    # does not validate defaults) and every attribute access crashed downstream.
+    with pytest.raises(ValidationError):
+        OrderMessage.model_validate({"source": "t", "type": "OrderMessage"})
+
+
+def test_typed_subclass_validates_data_shape():
+    with pytest.raises(ValidationError):
+        OrderMessage.model_validate(
+            {"source": "t", "type": "OrderMessage", "data": {"unexpected": 1}}
+        )
+
+
+def test_typed_subclass_accepts_valid_data():
+    msg = OrderMessage.model_validate(
+        {"source": "t", "type": "OrderMessage", "data": {"order_id": 7}}
+    )
+    assert isinstance(msg.data, Order)
+    assert msg.data.order_id == 7
+
+
+def test_message_still_defaults_to_empty_dict():
+    # The dict default lives on the concrete Message, where it is honest.
+    msg = Message(source="t", type="test.event")
+    assert msg.data == {}
+
+
+def test_message_roundtrips_without_data_key():
+    msg = Message.model_validate({"source": "t", "type": "test.event"})
+    assert msg.data == {}

--- a/sdk/tests/test_tracing.py
+++ b/sdk/tests/test_tracing.py
@@ -6,19 +6,19 @@ import asyncio
 
 import pytest
 
-from eggai.schemas import BaseMessage
+from eggai.schemas import Message
 from eggai.transport import InMemoryTransport, eggai_set_default_transport
 
 
 def test_traceparent_default_none():
-    msg = BaseMessage(source="test", type="test.event")
+    msg = Message(source="test", type="test.event")
     assert msg.traceparent is None
 
 
 def test_traceparent_survives_json_round_trip():
     tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-    msg = BaseMessage(source="test", type="test.event", traceparent=tp)
-    restored = BaseMessage.model_validate_json(msg.model_dump_json())
+    msg = Message(source="test", type="test.event", traceparent=tp)
+    restored = Message.model_validate_json(msg.model_dump_json())
     assert restored.traceparent == tp
 
 
@@ -42,7 +42,7 @@ async def test_noop_publish_and_subscribe_work_without_setup_tracing():
 
     await channel.subscribe(handler)
     await transport.connect()
-    await channel.publish(BaseMessage(source="test", type="test.noop"))
+    await channel.publish(Message(source="test", type="test.noop"))
 
     await asyncio.sleep(0.05)
     assert len(received) == 1
@@ -101,7 +101,7 @@ async def test_span_publish_creates_producer_span(fresh_transport):
 
         ch = Channel("tracing-pub-test", transport=fresh_transport)
         await fresh_transport.connect()
-        await ch.publish(BaseMessage(source="svc", type="test.pub"))
+        await ch.publish(Message(source="svc", type="test.pub"))
 
         spans = _SHARED_EXPORTER.get_finished_spans()
         assert len(spans) == 1
@@ -127,7 +127,7 @@ async def test_span_process_creates_consumer_span_with_same_trace_id(fresh_trans
 
         await ch.subscribe(handler)
         await fresh_transport.connect()
-        await ch.publish(BaseMessage(source="svc", type="test.proc"))
+        await ch.publish(Message(source="svc", type="test.proc"))
         await asyncio.sleep(0.1)
 
         spans = _SHARED_EXPORTER.get_finished_spans()
@@ -161,7 +161,7 @@ async def test_span_existing_traceparent_continues_the_trace(fresh_transport):
         await ch.subscribe(handler)
         await fresh_transport.connect()
         await ch.publish(
-            BaseMessage(source="svc", type="test.incoming", traceparent=external_tp)
+            Message(source="svc", type="test.incoming", traceparent=external_tp)
         )
 
         await asyncio.wait_for(done.wait(), timeout=2.0)
@@ -193,7 +193,7 @@ async def test_span_multi_hop_shares_single_trace_id(fresh_transport):
                 else getattr(msg, "traceparent", None)
             )
             await ch_b.publish(
-                BaseMessage(source="svc-a", type="test.hop.b", traceparent=tp)
+                Message(source="svc-a", type="test.hop.b", traceparent=tp)
             )
 
         async def handler_b(msg):
@@ -203,7 +203,7 @@ async def test_span_multi_hop_shares_single_trace_id(fresh_transport):
         await ch_b.subscribe(handler_b)
         await fresh_transport.connect()
 
-        await ch_a.publish(BaseMessage(source="origin", type="test.hop.a"))
+        await ch_a.publish(Message(source="origin", type="test.hop.a"))
 
         await asyncio.wait_for(done.wait(), timeout=2.0)
         await asyncio.sleep(0.05)


### PR DESCRIPTION
## The bug

`BaseMessage` declares a dict default on a field typed `TData`:

```python
data: TData = Field(default_factory=dict)
```

Pydantic **does not validate defaults**, so for every typed subclass anyone writes:

```python
class OrderMessage(BaseMessage[Order]):
    type: str = "OrderMessage"

OrderMessage.model_validate({"source": "t", "type": "OrderMessage"})  # no data key
# -> validates cleanly, data == {} (a plain dict, not an Order)
```

The annotation promises `Order`; the runtime value is `{}`. The typed-subscription path (`wrap_handler_with_filters`) sees a successful validation and a matching `type`, and hands the envelope to the handler — which crashes with `AttributeError: 'dict' object has no attribute ...` on the first `event.data.<attr>` access.

Under the Redis transport's default `AckPolicy.NACK_ON_ERROR` (with no `retry_on_idle_ms` reclaimer), that exception means the entry is never acked: one malformed envelope sits in the PEL and wedges the subscription across restarts. We hit this in code review on eggai-tech/outlook-connector#14. mypy `--strict` also flags the declaration itself: `Incompatible types in assignment (expression has type "dict[Never, Never]", variable has type "TData")`.

## The fix

- `BaseMessage.data` is now **required**. A missing or malformed payload fails validation, which `wrap_handler_with_filters` already treats as "not ours: skip and ack" — bad envelopes are dropped cleanly instead of delivered with a lying annotation.
- The `{}` default moves to the concrete `Message`, where the annotation genuinely is `dict[str, Any]`. `Message(source=…, type=…)` keeps working unchanged.

## Breaking change

Constructing a payload-less `BaseMessage` (or typed subclass) directly now raises. Migration: pass `data=` explicitly, or use `Message` for dict payloads. In-repo, only `tests/test_tracing.py` did this (updated); `adapters/a2a/executor.py` and the MCP models always pass `data=`. CHANGELOG entry added under Unreleased.

An alternative considered: keep the default and set `validate_default=True`. That is behavior-compatible for `Message` but keeps the type-dishonest declaration in the generic base; requiring the field is the smaller lie.

## Tests

- New `tests/test_schemas.py`: typed subclass rejects missing/malformed `data`, accepts valid payloads; `Message` still defaults to `{}` (constructor and `model_validate`).
- New cases in `tests/test_middleware_utils.py`: an envelope with a missing or malformed `data` is **skipped** (returns `None` → acked), never delivered as a dict.
- Full suite: 88 passed, 12 skipped (Kafka-only, no broker available) with a live Redis at localhost:6379; 37 passed without brokers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN5MGFqeXbohQ9LsjA9JCj
