### PR TITLE
fix(redis): stop double-prefixing stream keys with a non-default EGGAI_NAMESPACE

### DIFF
--- a/docs/docs/sdk/redis-transport.md
+++ b/docs/docs/sdk/redis-transport.md
@@ -98,7 +98,7 @@ The SDK automatically:
 
 ### How It Works
 
-Three Redis streams are involved:
+Three Redis streams are involved. The `eggai.` prefix is the default `EGGAI_NAMESPACE`, not a fixed prefix: with `EGGAI_NAMESPACE=prod` the keys become `prod.orders`, `prod.orders.<handler>.retry` and `prod.orders.<handler>.dlq`.
 
 | Stream | Purpose |
 |---|---|

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   swallow the `CancelledError` when the inner await completes concurrently, so
   the reclaimer task survived its own cancellation. The reclaimer loop now exits
   on a running flag as well as on cancellation.
+- **RedisTransport retries with a non-default `EGGAI_NAMESPACE`** (#261): the
+  reclaimer, group monitor, `.retry` and `.dlq` streams were keyed under
+  `eggai.<ns>.<topic>` while consumption and publishing used `<ns>.<topic>`, so
+  `retry_on_idle_ms` / `max_retries` never fired outside the default namespace.
+  The transport no longer adds its own `eggai.` prefix; `Channel` already
+  namespaces the name exactly once. After upgrading, entries stuck in the PEL
+  under a custom namespace are retried immediately and dead-lettered once the
+  retry budget is exhausted. Stale empty `eggai.<ns>.*` shadow keys can be
+  deleted.
 
 ### Changed
 - **BREAKING: `BaseMessage.data` is now required.** The generic base previously

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -215,6 +215,8 @@ No configuration needed — always active with `RedisTransport`.
 
 ### Retry delivery reference
 
+The `eggai.` prefix below is the default `EGGAI_NAMESPACE`, not a fixed prefix: with `EGGAI_NAMESPACE=prod` the same keys are `prod.orders`, `prod.orders.<handler>.retry` and `prod.orders.<handler>.dlq`.
+
 ```
 Main stream  (eggai.orders)
     │

--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -43,7 +43,7 @@ class _BinaryWriter:
 
 @dataclass(frozen=True)
 class ReclaimerConfig:
-    stream: str  # full Redis key, e.g. "eggai.orders"
+    stream: str  # full Redis key, e.g. "eggai.orders" (already namespaced by Channel)
     group: str  # consumer group name (mirrors handler_id)
     consumer: str  # distinct from live consumer: f"{handler_id}-reclaimer"
     retry_stream: str  # full Redis key for reclaimed messages; equals `stream` for the retry reclaimer

--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -43,7 +43,7 @@ class _BinaryWriter:
 
 @dataclass(frozen=True)
 class ReclaimerConfig:
-    stream: str  # full Redis key, e.g. "eggai.orders" (already namespaced by Channel)
+    stream: str  # full Redis key as given by Channel, e.g. "<namespace>.orders"
     group: str  # consumer group name (mirrors handler_id)
     consumer: str  # distinct from live consumer: f"{handler_id}-reclaimer"
     retry_stream: str  # full Redis key for reclaimed messages; equals `stream` for the retry reclaimer
@@ -51,7 +51,7 @@ class ReclaimerConfig:
     interval_s: float
     max_retries: int | None = None  # None = unlimited retries (no DLQ)
     dlq_stream: str | None = (
-        None  # full key, e.g. "eggai.orders.order-service-handle_order-1.dlq"
+        None  # full key, e.g. "<namespace>.orders.order-service-handle_order-1.dlq"
     )
     on_dlq: Callable | None = None  # async or sync callback(fields, msg_id, count)
     max_len: int | None = (

--- a/sdk/eggai/transport/redis.py
+++ b/sdk/eggai/transport/redis.py
@@ -500,7 +500,7 @@ class RedisTransport(Transport):
         main_sub_info = None
         if group:
             main_sub_info = _StreamGroupInfo(
-                stream_key=self._get_stream_key(channel),
+                stream_key=channel,
                 group=group,
                 group_create_id="$" if last_id == ">" else last_id,
             )
@@ -552,7 +552,7 @@ class RedisTransport(Transport):
             added_reclaimer_keys: list[tuple[str, str, str]] = []
             # The recursive subscribe below adds this entry (last_id=">" → "$").
             retry_sub_info = _StreamGroupInfo(
-                stream_key=self._get_stream_key(retry_stream),
+                stream_key=retry_stream,
                 group=retry_handler_id,
                 group_create_id="$",
             )
@@ -726,14 +726,14 @@ class RedisTransport(Transport):
             )
         return self._reclaimer_manager.add(
             ReclaimerConfig(
-                stream=self._get_stream_key(stream),
+                stream=stream,
                 group=group,
                 consumer=consumer,
-                retry_stream=self._get_stream_key(retry_stream),
+                retry_stream=retry_stream,
                 min_idle_ms=min_idle_ms,
                 interval_s=interval_s,
                 max_retries=max_retries,
-                dlq_stream=self._get_stream_key(dlq_stream) if dlq_stream else None,
+                dlq_stream=dlq_stream,
                 on_dlq=on_dlq,
                 max_len=self._retry_max_len,
                 backoff_multiplier=backoff_multiplier,
@@ -741,9 +741,3 @@ class RedisTransport(Transport):
                 backoff_jitter=backoff_jitter,
             )
         )
-
-    @staticmethod
-    def _get_stream_key(channel: str) -> str:
-        if channel.startswith("eggai."):
-            return channel
-        return f"eggai.{channel}"

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -373,6 +373,74 @@ async def test_retry_on_idle_ms_basic():
 
 
 @pytest.mark.asyncio
+async def test_retry_and_dlq_fire_with_non_default_namespace(monkeypatch):
+    """Regression test for issue #261.
+
+    With a non-default EGGAI_NAMESPACE the transport used to consume on
+    ``<ns>.<topic>`` while the reclaimer, retry and DLQ streams lived under
+    ``eggai.<ns>.<topic>``, so retries never fired. Asserts that a failing
+    handler is retried and finally dead-lettered on the namespaced keys, and
+    that no ``eggai.``-prefixed shadow keys are created.
+    """
+    import eggai.channel as channel_mod
+
+    namespace = f"ns{uuid.uuid4().hex[:6]}"
+    monkeypatch.setattr(channel_mod, "NAMESPACE", namespace)
+
+    # DLQ payloads are binary-framed; do not decode responses.
+    redis_client = redis.Redis(host="localhost", port=6379, decode_responses=False)
+
+    test_id = uuid.uuid4().hex[:8]
+    channel_name = f"test-ns-retry-{test_id}"
+    stream_name = f"{namespace}.{channel_name}"
+    group_main = f"ns-agent-{test_id}-always_fails-1"
+    retry_stream_name = f"{stream_name}.{group_main}.retry"
+    dlq_stream_name = f"{stream_name}.{group_main}.dlq"
+
+    transport = RedisTransport()
+    agent = Agent(f"ns-agent-{test_id}", transport=transport)
+    channel = Channel(channel_name, transport=transport)
+    assert channel.get_name() == stream_name
+
+    call_count = 0
+
+    @agent.subscribe(
+        channel=channel,
+        retry_on_idle_ms=300,
+        retry_reclaim_interval_s=0.5,
+        max_retries=1,
+    )
+    async def always_fails(message):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("poison message")
+
+    await agent.start()
+    await channel.publish({"type": "test", "data": "poison", "test_id": test_id})
+
+    dlq_entries = []
+    for _ in range(30):
+        await asyncio.sleep(1.0)
+        if await redis_client.exists(dlq_stream_name):
+            dlq_entries = await redis_client.xrange(dlq_stream_name)
+            if dlq_entries:
+                break
+
+    await agent.stop()
+
+    shadow_keys = await redis_client.keys(f"eggai.{namespace}.*".encode())
+    retry_len = await redis_client.xlen(retry_stream_name)
+    await redis_client.aclose()
+
+    assert call_count >= 2, f"Handler was never retried (calls={call_count})"
+    assert retry_len >= 1, (
+        "Retry stream on the namespaced key never received the message"
+    )
+    assert len(dlq_entries) == 1, "Message never arrived in the namespaced DLQ stream"
+    assert shadow_keys == [], f"Unexpected eggai.-prefixed shadow keys: {shadow_keys}"
+
+
+@pytest.mark.asyncio
 async def test_retry_does_not_fan_out_to_other_handlers():
     """
     Regression test for issue #225.
@@ -544,8 +612,12 @@ async def test_retry_on_idle_ms_conflict_with_min_idle_time():
 
 
 @pytest.mark.asyncio
-async def test_retry_on_idle_ms_uses_prefixed_stream_keys():
-    """Reclaimer configs must target the actual Redis stream keys used by FastStream."""
+async def test_retry_on_idle_ms_uses_channel_stream_keys():
+    """Reclaimer configs must target the exact Redis stream keys FastStream uses.
+
+    The channel name arrives already namespaced by ``Channel`` (issue #261);
+    the transport must not add a second prefix.
+    """
     transport = RedisTransport()
 
     async def handler(message):
@@ -566,16 +638,16 @@ async def test_retry_on_idle_ms_uses_prefixed_stream_keys():
     )
 
     assert len(configs) == 2
-    assert configs[0].stream == "eggai.orders"
+    assert configs[0].stream == "orders"
     # Per-handler retry/dlq keys (issue #225).
-    assert configs[0].retry_stream == "eggai.orders.orders-handler-1.retry"
+    assert configs[0].retry_stream == "orders.orders-handler-1.retry"
     # Default max_retries=5 should set up DLQ stream
     assert configs[0].max_retries == 5
-    assert configs[0].dlq_stream == "eggai.orders.orders-handler-1.dlq"
-    assert configs[1].stream == "eggai.orders.orders-handler-1.retry"
-    assert configs[1].retry_stream == "eggai.orders.orders-handler-1.retry"
+    assert configs[0].dlq_stream == "orders.orders-handler-1.dlq"
+    assert configs[1].stream == "orders.orders-handler-1.retry"
+    assert configs[1].retry_stream == "orders.orders-handler-1.retry"
     assert configs[1].max_retries == 5
-    assert configs[1].dlq_stream == "eggai.orders.orders-handler-1.dlq"
+    assert configs[1].dlq_stream == "orders.orders-handler-1.dlq"
 
 
 @pytest.mark.asyncio
@@ -626,9 +698,9 @@ async def test_retry_stream_pins_last_id_to_new_entries():
 
     subs = {s.stream_key: s for s in transport._stream_subscriptions}
     # Main stream honours the operator's replay request...
-    assert subs["eggai.orders"].group_create_id == "0"
+    assert subs["orders"].group_create_id == "0"
     # ...but the retry stream is pinned to new entries regardless ("$" == ">").
-    assert subs["eggai.orders.orders-handler-1.retry"].group_create_id == "$"
+    assert subs["orders.orders-handler-1.retry"].group_create_id == "$"
 
 
 @pytest.mark.asyncio
@@ -682,7 +754,7 @@ async def test_duplicate_subscribe_dedups_stream_subscriptions():
     await transport.subscribe("orders", handler, handler_id="orders-handler-1")
 
     orders_infos = [
-        s for s in transport._stream_subscriptions if s.stream_key == "eggai.orders"
+        s for s in transport._stream_subscriptions if s.stream_key == "orders"
     ]
     assert len(orders_infos) == 1
 
@@ -1033,7 +1105,7 @@ async def test_max_retries_validation():
 
 @pytest.mark.asyncio
 async def test_dlq_stream_naming():
-    """Reclaimer configs get the correct DLQ stream name with eggai. prefix."""
+    """Reclaimer configs derive the DLQ stream name from the channel as given."""
     transport = RedisTransport()
 
     async def handler(message):
@@ -1050,7 +1122,7 @@ async def test_dlq_stream_naming():
     assert transport._reclaimer_manager is not None
 
     configs = list(transport._reclaimer_manager._configs.values())
-    expected_dlq = "eggai.orders.orders-handler-1.dlq"
+    expected_dlq = "orders.orders-handler-1.dlq"
     for config in configs:
         assert config.dlq_stream == expected_dlq, (
             f"Expected dlq_stream={expected_dlq!r}, got {config.dlq_stream}"
@@ -1075,9 +1147,9 @@ async def test_monitor_tracks_stream_subscriptions():
     # Main subscription + retry subscription
     assert len(transport._stream_subscriptions) == 2
     stream_keys = [s.stream_key for s in transport._stream_subscriptions]
-    assert "eggai.orders" in stream_keys
+    assert "orders" in stream_keys
     # Per-handler retry stream key (issue #225).
-    assert "eggai.orders.orders-handler-1.retry" in stream_keys
+    assert "orders.orders-handler-1.retry" in stream_keys
 
     groups = [s.group for s in transport._stream_subscriptions]
     assert "orders-handler-1" in groups

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.12"


### PR DESCRIPTION
Fixes #261

## Problem

`Channel` namespaces the topic once (`<ns>.<topic>`), and that is the name FastStream consumes and publishes on. `RedisTransport._get_stream_key()` then added a second `eggai.` prefix for everything the SDK manages itself: the pending-entry reclaimer, the consumer-group monitor, and the `.retry` / `.dlq` streams. With any `EGGAI_NAMESPACE` other than the default `eggai`, the retry machinery watched `eggai.<ns>.<topic>` while traffic flowed on `<ns>.<topic>`, so `retry_on_idle_ms` and `max_retries` were dead configuration. The default namespace masked this because the prefix was a no-op there.

## Fix

- Delete `_get_stream_key()` and pass the channel-derived names through unchanged at all five call sites (`sdk/eggai/transport/redis.py`). The namespace is applied exactly once, in `Channel`.
- Update the five unit tests that asserted the double prefix when subscribing with a bare channel name.
- Add `test_retry_and_dlq_fire_with_non_default_namespace`: runs a failing handler under a random namespace, asserts the message is retried and dead-lettered on the namespaced keys, and asserts no `eggai.<ns>.*` shadow keys are created. Fails on `main`, passes here.
- Changelog entry under Unreleased.

## Behaviour change for operators

Users on a non-default namespace who did not use the `EGGAI_NAMESPACE=eggai.<ns>` workaround will, after upgrading, have the reclaimer see their real pending entries. Anything stuck for hours is retried immediately and dead-lettered once the retry budget is exhausted. The old `eggai.<ns>.*` shadow keys were empty and can be deleted. Default-namespace users and workaround users see identical keys before and after.

## Verification

```
sdk/.venv/bin/python -m pytest tests/test_redis.py tests/test_namespace.py -q
57 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ggje52AxgskNL6LJiTqpsi
