### PR TITLE
chore(ci): harden workflows, bump actions, drop Gr1N/setup-poetry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,15 +16,15 @@ jobs:
     name: Code quality checks
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pypoetry
@@ -35,7 +35,7 @@ jobs:
             poetry-${{ runner.os }}-
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
+        run: pipx install poetry==2.4.3
 
       - name: Copy README to SDK
         run: cp README.md sdk/
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -150,15 +150,15 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pypoetry
@@ -169,7 +169,7 @@ jobs:
             poetry-${{ runner.os }}-
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
+        run: pipx install poetry==2.4.3
 
       - name: Copy README to SDK
         run: cp README.md sdk/
@@ -184,9 +184,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          file: sdk/coverage.xml
+          files: sdk/coverage.xml
           flags: unittests
           name: python-${{ matrix.python-version }}
           fail_ci_if_error: false
@@ -196,15 +196,15 @@ jobs:
     name: Build and verify SDK package
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 
       - name: Cache Poetry dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/pypoetry
@@ -215,7 +215,7 @@ jobs:
             poetry-${{ runner.os }}-
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
+        run: pipx install poetry==2.4.3
 
       - name: Copy README to SDK
         run: cp README.md sdk/

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: release-${{ github.repository }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     if: >
@@ -22,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -71,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 
@@ -99,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Create and push tag
         env:
@@ -135,14 +138,14 @@ jobs:
 
       - name: Download distributions
         if: steps.check.outputs.exists == 'false'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/
 
       - name: Publish to PyPI
         if: steps.check.outputs.exists == 'false'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release:
     needs: [prepare, build-and-test, create-tag]
@@ -152,10 +155,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/qualops.yml
+++ b/.github/workflows/qualops.yml
@@ -13,9 +13,10 @@ on:
 jobs:
   review:
     name: AI Code Review
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,20 +8,23 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
 
     steps:
       - name: Generate app token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,5 +12,5 @@ https://github.com/eggai-tech/EggAI/security/advisories/new
 
 | Version | Supported |
 | ------- | --------- |
-| 0.2.x   | ✓         |
-| < 0.2.0 | ✗         |
+| 0.3.x   | ✓         |
+| < 0.3.0 | ✗         |


### PR DESCRIPTION
## Summary

- Top-level `permissions: contents: read` on `release.yaml` and `python-publish.yaml`. Fixes the 3 open CodeQL `actions/missing-workflow-permissions` alerts. Per-job `write` grants are unchanged.
- Bump pinned actions to Node 24 releases: checkout v7.0.0, setup-python v6.3.0, cache v6.1.0, codecov-action v7.0.0, download-artifact v8.0.1, gh-action-pypi-publish v1.14.2, create-github-app-token v3.2.0. Supersedes Dependabot #235, #238, #248, #249, #250.
- Replace `Gr1N/setup-poetry` (Node 20, no Node 24 release) with `pipx install poetry==2.4.3`.
- codecov-action: the `file` input no longer exists, rename to `files` (fixes the "Unexpected input(s) 'file'" annotation on every run).
- QualOps review job skipped for Dependabot PRs; it has no access to `ANTHROPIC_API_KEY` and fails on every one.
- SECURITY.md: supported versions 0.3.x.

## Verification

`actionlint` clean (only pre-existing shellcheck SC2086 info notes in unchanged run scripts). Publish workflow cannot be exercised before a release; upload-artifact v7 / download-artifact v8 both use Artifact API v2 and interoperate.