### PR TITLE
fix(redis): reclaimer stop no longer depends on cancellation reaching the loop

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `RedisTransport`: `agent.stop()` could hang forever on Python 3.10/3.11 with
+  redis-py >= 8. redis-py 8 sends every command through `asyncio.wait_for`
+  (`socket_timeout` now defaults to 5s), and on CPython < 3.12 `wait_for` can
+  swallow the `CancelledError` when the inner await completes concurrently, so
+  the reclaimer task survived its own cancellation. The reclaimer loop now exits
+  on a running flag as well as on cancellation.
+
 ### Changed
 - **BREAKING: `BaseMessage.data` is now required.** The generic base previously
   declared `data: TData = Field(default_factory=dict)`. Pydantic does not

--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -150,6 +150,7 @@ class PendingReclaimerManager:
         self._redis_client: aioredis.Redis | None = None
         self._configs: dict[tuple[str, str, str], ReclaimerConfig] = {}
         self._tasks: dict[tuple[str, str, str], asyncio.Task] = {}
+        self._running = False
 
     def add(self, config: ReclaimerConfig) -> tuple[str, str, str]:
         key = (config.stream, config.group, config.consumer)
@@ -169,6 +170,7 @@ class PendingReclaimerManager:
             self._redis_url,
             **{**self._connection_kwargs, "decode_responses": False},
         )
+        self._running = True
         for key, config in self._configs.items():
             if key in self._tasks and not self._tasks[key].done():
                 continue
@@ -178,20 +180,20 @@ class PendingReclaimerManager:
 
     async def stop(self) -> None:
         """Cancel all reclaimer tasks and close the Redis connection."""
+        self._running = False
         for task in self._tasks.values():
             task.cancel()
-        for task in self._tasks.values():
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        await asyncio.gather(*self._tasks.values(), return_exceptions=True)
         self._tasks.clear()
         if self._redis_client is not None:
             await self._redis_client.aclose()
             self._redis_client = None
 
     async def _run(self, config: ReclaimerConfig) -> None:
-        while True:
+        # The flag, not just cancellation, ends the loop: redis-py >= 8 sends every
+        # command through asyncio.wait_for, which on CPython < 3.12 can swallow the
+        # CancelledError, so a cancelled reclaim may return normally.
+        while self._running:
             # Sleep first so the broker has settled before the first scan.
             await asyncio.sleep(config.interval_s)
             try:

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -2031,3 +2031,52 @@ async def test_backoff_reclaims_message_once_threshold_elapsed():
     await manager._redis_client.aclose()
     await client.delete(stream, retry_stream)
     await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_reclaimer_stop_completes_when_cancellation_is_swallowed(monkeypatch):
+    """stop() must return even if the cancellation never reaches _run().
+
+    redis-py >= 8 sends every command through asyncio.wait_for (socket_timeout
+    now defaults to 5s); on CPython < 3.12 wait_for can swallow the
+    CancelledError when the inner await completes concurrently, so the reclaim
+    call returns normally and the loop must exit on its own.
+    """
+    from eggai.transport.pending_reclaimer import (
+        PendingReclaimerManager,
+        ReclaimerConfig,
+    )
+
+    manager = PendingReclaimerManager("redis://localhost:6379")
+    manager.add(
+        ReclaimerConfig(
+            stream="eggai.swallow",
+            group="g",
+            consumer="g-reclaimer",
+            retry_stream="eggai.swallow.g.retry",
+            min_idle_ms=1,
+            interval_s=0.01,
+        )
+    )
+    entered = asyncio.Event()
+    swallowed = False
+
+    async def swallowing_reclaim(config):
+        nonlocal swallowed
+        entered.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            if swallowed:
+                raise
+            swallowed = True
+
+    monkeypatch.setattr(manager, "_reclaim_once", swallowing_reclaim)
+
+    await manager.start()
+    await asyncio.wait_for(entered.wait(), timeout=2)
+
+    stop_task = asyncio.create_task(manager.stop())
+    await asyncio.wait({stop_task}, timeout=2)
+    assert stop_task.done(), "stop() hung after the cancellation was swallowed"
+    await stop_task


### PR DESCRIPTION
## Problem

`agent.stop()` hangs forever on Python 3.10 and 3.11 once redis-py 8 is installed. Surfaced by the lockfile refresh in #265: the 3.12 and 3.13 test jobs finished in 90s, the 3.10 and 3.11 jobs sat in `pytest` until cancelled. Reproduced locally: `test_retry_on_idle_ms_no_retry_retry_stream` hangs about 3 runs in 4 on 3.10/3.11 with redis-py 8.1.0, never with 7.4.0, never on 3.12.

## Cause

redis-py 8.0 changed the default `socket_timeout` from `None` to 5 seconds, so every command send now runs through `asyncio.wait_for(...)`. On CPython < 3.12 `wait_for` can swallow the `CancelledError` when the inner await completes at the same moment (gh-86296, fixed in 3.12 by the `asyncio.timeout` rewrite). The reclaimer's `_reclaim_once` therefore returned normally after `task.cancel()`, the `while True` loop went back to `asyncio.sleep()` in the cancelling state, and `stop()` awaited that task forever. Task dump at the hang:

```
Task-1  test_...  await agent.stop()
  waits on: <Task cancelling name='reclaimer:...' running at pending_reclaimer.py:196 await asyncio.sleep(config.interval_s)>
```

## Fix

- `PendingReclaimerManager` keeps a `_running` flag: set in `start()`, cleared in `stop()`. `_run` loops `while self._running`, so a swallowed cancellation ends the loop on the next iteration.
- `stop()` awaits the tasks with `gather(return_exceptions=True)` instead of `except CancelledError: pass`, so a caller's own cancellation is no longer masked.

## Verification (local, live Redis 7 + Redpanda)

| Python | redis-py | Result |
|---|---|---|
| 3.10.18 | 8.1.0 | 101 passed, hanging test 5/5 |
| 3.11.13 | 8.1.0 | 101 passed, hanging test 5/5 |
| 3.12.11 | 8.1.0 | 101 passed |

New test `test_reclaimer_stop_completes_when_cancellation_is_swallowed` simulates a swallowed cancellation deterministically; it fails on `main` (`stop()` never returns) and passes here.

#265 is rebased on this branch and includes this commit.