### PR TITLE
fix: byte-length header prefix in retry envelope, namespaced default channel in Agent.subscribe

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under a custom namespace are retried immediately and dead-lettered once the
   retry budget is exhausted. Stale empty `eggai.<ns>.*` shadow keys can be
   deleted.
+- `PendingReclaimer`: the retry envelope's header length prefix counted
+  characters instead of bytes, truncating non-ASCII header values on every
+  retry delivery (#263).
+- `Agent.subscribe()` without a channel listened on the literal `eggai.channel`
+  instead of `<EGGAI_NAMESPACE>.channel`, so under a custom namespace a bare
+  `Channel().publish()` never reached it (#264).
 
 ### Changed
 - **BREAKING: `BaseMessage.data` is now required.** The generic base previously

--- a/sdk/eggai/agent.py
+++ b/sdk/eggai/agent.py
@@ -73,7 +73,7 @@ class Agent:
         Decorator for adding a subscription.
 
         Args:
-            channel (Optional[Channel]): The channel to subscribe to. If None, defaults to "eggai.channel".
+            channel (Optional[Channel]): The channel to subscribe to. If None, defaults to "<namespace>.channel".
             **kwargs: Additional keyword arguments for the subscription and plugins.
 
         Returns:
@@ -81,7 +81,7 @@ class Agent:
         """
 
         def decorator(handler: Callable[[dict[str, Any]], "asyncio.Future"]):
-            channel_name = channel.get_name() if channel else "eggai.channel"
+            channel_name = (channel or Channel()).get_name()
             if "min_idle_time" in kwargs and "retry_on_idle_ms" in kwargs:
                 raise ValueError(
                     "min_idle_time and retry_on_idle_ms are mutually exclusive. "

--- a/sdk/eggai/channel.py
+++ b/sdk/eggai/channel.py
@@ -34,7 +34,7 @@ class Channel:
         Initialize a Channel instance.
 
         Args:
-            name (str): The channel (topic) name. Defaults to "eggai.channel".
+            name (str): The channel (topic) name. Defaults to "<namespace>.channel".
             transport (Optional[Transport]): A concrete transport instance. If None, a default transport is used.
         """
         self._name = f"{NAMESPACE}.{name or DEFAULT_CHANNEL_NAME}"

--- a/sdk/eggai/transport/pending_reclaimer.py
+++ b/sdk/eggai/transport/pending_reclaimer.py
@@ -34,8 +34,9 @@ class _BinaryWriter:
         self.write(pack(">I", number))
 
     def write_string(self, data: str | bytes) -> None:
-        self.write_short(len(data))
-        self.write(data.encode() if isinstance(data, str) else data)
+        raw = data.encode() if isinstance(data, str) else data
+        self.write_short(len(raw))
+        self.write(raw)
 
     def get_bytes(self) -> bytes:
         return bytes(self.data)

--- a/sdk/tests/test_namespace.py
+++ b/sdk/tests/test_namespace.py
@@ -1,9 +1,11 @@
+import asyncio
 from contextlib import contextmanager
 
 import pytest
 
 import eggai.channel
-from eggai import Channel
+from eggai import Agent, Channel
+from eggai.transport import InMemoryTransport, eggai_set_default_transport
 
 
 class TestNamespace:
@@ -34,3 +36,23 @@ class TestNamespace:
         with self._override_namespace(namespace):
             channel = Channel(name=channel_name)
             assert channel._name == expected
+
+    @pytest.mark.asyncio
+    async def test_agent_subscribe_default_channel_uses_namespace(self):
+        """Bare @agent.subscribe() and bare Channel() must resolve to the same name."""
+        eggai_set_default_transport(lambda: InMemoryTransport())
+        received = []
+        with self._override_namespace("custom"):
+            agent = Agent("namespace-agent")
+
+            @agent.subscribe()
+            async def handler(msg):
+                received.append(msg)
+
+            await agent.start()
+            await Channel().publish({"type": "ping"})
+            await asyncio.sleep(0.1)
+            await agent.stop()
+
+        assert agent._subscriptions[0][0] == "custom.channel"
+        assert len(received) == 1

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -854,6 +854,39 @@ async def test_inject_retry_metadata_malformed_payload(caplog):
     assert any("Failed to inject retry metadata" in r.message for r in caplog.records)
 
 
+def test_inject_retry_metadata_non_ascii_header():
+    """Header length prefixes are byte counts, so multi-byte UTF-8 values survive re-encoding."""
+    from struct import pack
+
+    from faststream.redis.parser.binary import BinaryMessageFormatV1
+
+    from eggai.transport.pending_reclaimer import _inject_retry_metadata
+
+    headers = {"correlation_id": "c1", "x-tenant": "münchen", "x-after": "abc"}
+    headers_bytes = b""
+    for key, value in headers.items():
+        for raw in (key.encode(), value.encode()):
+            headers_bytes += pack(">H", len(raw)) + raw
+    headers_start = 18
+    envelope = (
+        BinaryMessageFormatV1.IDENTITY_HEADER
+        + pack(">H", 1)
+        + pack(">I", headers_start)
+        + pack(">I", 2 + headers_start + len(headers_bytes))
+        + pack(">H", len(headers))
+        + headers_bytes
+        + b'{"type":"t","data":{}}'
+    )
+
+    new_data, count, parsed_ok = _inject_retry_metadata(envelope, "1-0")
+
+    assert parsed_ok is True
+    assert count == 1
+    body, parsed_headers = BinaryMessageFormatV1.parse(new_data)
+    assert parsed_headers == headers
+    assert json.loads(body)["_retry_count"] == "1"
+
+
 @pytest.mark.asyncio
 async def test_reclaimer_manager_start_stop_cycles():
     """PendingReclaimerManager handles repeated start/stop without leaking clients."""


### PR DESCRIPTION
Fixes #263, fixes #264. Both reported by @afiodorov; both confirmed by reproduction on `main`.

## #263: `_BinaryWriter.write_string` used the character count as the length prefix

The retry path re-encodes the FastStream binary envelope to stamp `_retry_count`. The writer emitted `len(data)` (characters) and then `data.encode()` (bytes), so a header such as `x-tenant: münchen` came back as `münch` and every following header was misaligned. Encode first, prefix with the byte length. Reproduced: `{'x-tenant': 'münch'}` on `main`, intact after the fix.

Note for the issue: FastStream 0.7.5's own `BinaryWriter.write_string` has the identical bug at publish time, so non-ASCII headers are still truncated once upstream before the reclaimer sees them. This PR stops the SDK from adding a second truncation; the regression test therefore builds the envelope by hand rather than through FastStream's encoder. Worth an upstream issue at ag2ai/faststream.

## #264: `Agent.subscribe()` fallback hardcoded `eggai.channel`

`Channel()` resolves to `<EGGAI_NAMESPACE>.channel`, the fallback did not, so under a custom namespace a bare `Channel().publish()` never reached a bare `@agent.subscribe()`. The fallback now goes through `Channel()`; docstrings updated. Regression test overrides the namespace, subscribes bare, publishes bare, asserts delivery. No other hardcoded `eggai.` prefix bypassing the namespace remains after #262.

## Verification (local, live Redis 7 + Redpanda, Python 3.12, redis-py 8.1.0)

- both new tests fail on unfixed code (2 failed), pass with the fix (2 passed)
- full suite on this branch: 103 passed, 0 skipped
- ruff check / format clean