### PR TITLE
feat(redis): group_start subscribe option, reject last_id with a consumer group

### DIFF
--- a/docs/docs/sdk/redis-transport.md
+++ b/docs/docs/sdk/redis-transport.md
@@ -59,6 +59,23 @@ transport = RedisTransport(
 
 The `url` accepts `redis://`, `rediss://` (TLS), and `unix://` schemes.
 
+### Consuming an Existing Backlog
+
+A consumer group is created at `$` by default: it only sees entries published
+after it exists. To let a new consumer pick up the entries already in the
+stream, pass `group_start="0"` (or an explicit stream id):
+
+```python
+@agent.subscribe(channel=orders, group_start="0")
+async def handle_order(message):
+    ...
+```
+
+`group_start` only applies when the group does not exist yet. A group remembers
+its position across restarts, so this does not replay the stream every time the
+service starts. `last_id` is for group-less subscriptions only and is rejected
+together with a consumer group.
+
 ## Reliable Message Delivery
 
 ### The Problem: Stuck Messages

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `RedisTransport`: new `group_start` subscribe option (`"$"` default, `"0"` or
+  a stream id) chooses where a NEW consumer group starts reading, so a consumer
+  added to a channel that already carries traffic can pick up the existing
+  backlog. The transport now creates its consumer groups itself before the
+  broker starts (#260).
+
 ### Fixed
 - `RedisTransport`: `agent.stop()` could hang forever on Python 3.10/3.11 with
   redis-py >= 8. redis-py 8 sends every command through `asyncio.wait_for`
@@ -44,6 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `data=` explicitly).
 - Allow ruff 0.16 (`ruff >=0.14.4,<0.17`) and exclude Markdown from ruff, which
   now formats fenced code blocks by default.
+- `RedisTransport`: `last_id` other than `">"` together with a consumer group
+  now raises `ValueError`. That combination never delivered new entries (Redis
+  returns only the consumer's own pending entries for an explicit id) and
+  hot-looped XREADGROUP; the earlier note about replaying a backlog with
+  `last_id="0"` was wrong. Use `group_start="0"` instead.
 
 ## [0.3.4] - 2026-08-19
 

--- a/sdk/eggai/transport/redis.py
+++ b/sdk/eggai/transport/redis.py
@@ -193,6 +193,7 @@ class RedisTransport(Transport):
         # subscribers that aren't running yet (e.g. those a second Agent just
         # registered). Falls back to the original full start() if FastStream ever
         # stops exposing the `running` flags.
+        await self._create_groups()
         if not getattr(self.broker, "running", False):
             await self.broker.start()
         else:
@@ -286,7 +287,12 @@ class RedisTransport(Transport):
                 a distinct slice of the PEL. Pass an explicit value only if you need a stable consumer name.
             batch (bool, optional): Whether to consume messages in batches (default is False).
             max_records (Optional[int], optional): Maximum number of records to consume in one batch (default is None).
-            last_id (str, optional): Starting message ID for stream consumption (default is ">" for consumer groups).
+            group_start (str, optional): Stream id a NEW consumer group is created at: "$" (default, only entries
+                published after the group exists), "0" (the whole existing backlog) or an explicit stream id.
+                Ignored when the group already exists, a group remembers its own position. Reads always use ">".
+            last_id (str, optional): Starting message ID for group-less (XREAD) subscriptions (default is ">").
+                Not allowed together with a consumer group: XREADGROUP with an explicit id only returns this
+                consumer's own pending entries, never new ones. Use group_start instead.
             no_ack (bool, optional): Whether to skip acknowledgment of stream messages (default is False for durability).
             ack_policy (AckPolicy, optional): Acknowledgment policy for message handling (default is AckPolicy.NACK_ON_ERROR).
                 - NACK_ON_ERROR: Messages are NOT acknowledged on handler errors, allowing redelivery (recommended).
@@ -415,9 +421,17 @@ class RedisTransport(Transport):
         batch = kwargs.pop("batch", False)
         max_records = kwargs.pop("max_records", None)
         last_id = kwargs.pop("last_id", ">")
+        group_start = kwargs.pop("group_start", "$")
         no_ack = kwargs.pop("no_ack", False)
         min_idle_time = kwargs.pop("min_idle_time", None)
 
+        if group and last_id != ">":
+            raise ValueError(
+                "last_id is only meaningful without a consumer group: XREADGROUP with "
+                "an explicit id returns this consumer's own pending entries and never "
+                'new ones. Use group_start="0" (or a stream id) to choose where a new '
+                "group starts reading."
+            )
         if min_idle_time is not None and retry_on_idle_ms is not None:
             raise ValueError(
                 "min_idle_time and retry_on_idle_ms are mutually exclusive. "
@@ -502,7 +516,7 @@ class RedisTransport(Transport):
             main_sub_info = _StreamGroupInfo(
                 stream_key=channel,
                 group=group,
-                group_create_id="$" if last_id == ">" else last_id,
+                group_create_id=group_start,
             )
             self._stream_subscriptions.add(main_sub_info)
 
@@ -550,7 +564,7 @@ class RedisTransport(Transport):
             # The FastStream broker subscriber(s) cannot be un-registered, but
             # nothing is live until connect(), which never runs on failure.
             added_reclaimer_keys: list[tuple[str, str, str]] = []
-            # The recursive subscribe below adds this entry (last_id=">" → "$").
+            # The recursive subscribe below adds this entry (retry groups start at "$").
             retry_sub_info = _StreamGroupInfo(
                 stream_key=retry_stream,
                 group=retry_handler_id,
@@ -648,6 +662,32 @@ class RedisTransport(Transport):
                 raise
 
         return registered_handler
+
+    async def _create_groups(self) -> None:
+        """Create every registered consumer group at its group_start before the
+        subscribers start. FastStream creates groups at "$" for last_id=">", so
+        creating them here first turns its call into a BUSYGROUP no-op and reads
+        use ">" from a group that starts where the caller asked."""
+        if not self._stream_subscriptions:
+            return
+        client = aioredis.from_url(
+            self._redis_url,
+            **{**self._connection_kwargs, "decode_responses": True},
+        )
+        try:
+            for info in list(self._stream_subscriptions):
+                try:
+                    await client.xgroup_create(
+                        name=info.stream_key,
+                        groupname=info.group,
+                        id=info.group_create_id,
+                        mkstream=True,
+                    )
+                except ResponseError as e:
+                    if "BUSYGROUP" not in str(e):
+                        raise
+        finally:
+            await client.aclose()
 
     async def _monitor_stream_groups(self) -> None:
         """Periodically ensure all registered stream consumer groups exist.

--- a/sdk/tests/test_redis.py
+++ b/sdk/tests/test_redis.py
@@ -675,10 +675,10 @@ async def test_retry_on_idle_ms_rejects_acking_ack_policies(policy):
 
 
 @pytest.mark.asyncio
-@pytest.mark.filterwarnings("ignore:.*polling_interval.*:RuntimeWarning")
 async def test_retry_stream_pins_last_id_to_new_entries():
     """The retry stream must consume only new entries, even when the operator
-    replays the main stream with last_id='0' (issue #225 review).
+    starts the main group at the beginning of the stream with group_start="0"
+    (issue #225 review).
 
     Otherwise restarting with last_id='0' to re-drain the main backlog would
     also replay the retry stream's history on every restart.
@@ -693,7 +693,7 @@ async def test_retry_stream_pins_last_id_to_new_entries():
         handler,
         handler_id="orders-handler-1",
         retry_on_idle_ms=500,
-        last_id="0",
+        group_start="0",
     )
 
     subs = {s.stream_key: s for s in transport._stream_subscriptions}
@@ -2185,3 +2185,61 @@ async def test_reclaimer_stop_completes_when_cancellation_is_swallowed(monkeypat
     await asyncio.wait({stop_task}, timeout=2)
     assert stop_task.done(), "stop() hung after the cancellation was swallowed"
     await stop_task
+
+
+@pytest.mark.asyncio
+async def test_last_id_with_group_is_rejected():
+    transport = RedisTransport()
+
+    async def handler(message):
+        return message
+
+    with pytest.raises(ValueError, match="group_start"):
+        await transport.subscribe(
+            "orders", handler, handler_id="orders-handler-1", last_id="0"
+        )
+
+
+@pytest.mark.asyncio
+async def test_group_start_zero_delivers_backlog_and_new_entries():
+    """A new consumer with group_start="0" receives the entries published before
+    it existed and the ones published afterwards; a restart (group already
+    exists) keeps delivering only new entries (issue #260)."""
+    test_id = uuid.uuid4().hex[:8]
+    channel_name = f"test-group-start-{test_id}"
+    group = f"group-start-agent-{test_id}-handler-1"
+
+    producer = RedisTransport()
+    await producer.connect()
+    channel = Channel(channel_name, transport=producer)
+    await channel.publish({"type": "t", "data": {"n": 1}})
+    await channel.publish({"type": "t", "data": {"n": 2}})
+
+    async def run(expected, **sub_kwargs):
+        received = []
+        done = asyncio.Event()
+        transport = RedisTransport()
+        agent = Agent(f"group-start-agent-{test_id}", transport=transport)
+
+        @agent.subscribe(
+            channel=Channel(channel_name, transport=transport), **sub_kwargs
+        )
+        async def handler(message):
+            received.append(message["data"]["n"])
+            if len(received) == len(expected):
+                done.set()
+
+        await agent.start()
+        await channel.publish({"type": "t", "data": {"n": expected[-1]}})
+        await asyncio.wait_for(done.wait(), timeout=5.0)
+        await agent.stop()
+        assert received == expected
+
+    await run([1, 2, 3], group=group, group_start="0")
+    # Restart with the same, now existing, group: only new entries, no replay.
+    await run([4], group=group, group_start="0")
+
+    redis_client = redis.Redis(host="localhost", port=6379)
+    await redis_client.delete(f"eggai.{channel_name}")
+    await redis_client.aclose()
+    await producer.disconnect()


### PR DESCRIPTION
Fixes #260 (reported by @afiodorov).

## Problem

A consumer group is created at `$`, so a consumer added to a channel that already carries traffic never sees the backlog. The documented workaround `last_id="0"` cannot work: FastStream feeds the same id to `XGROUP CREATE` and to every `XREADGROUP`, and `XREADGROUP` with an explicit id returns only the consumer's own pending entries. Measured on FastStream 0.7.5 with an existing group: zero deliveries and roughly 8000 `XREADGROUP` calls per second. FastStream 0.7.5 exposes no separate group-create id (`StreamSub` has no such slot), so the SDK has to create the group itself.

## Change

- `subscribe(..., group_start="$")`: `"$"` (default), `"0"` or an explicit stream id. Stored as the group's `group_create_id`.
- `connect()` creates every registered group at its `group_start` before the broker starts (`XGROUP CREATE ... MKSTREAM`, `BUSYGROUP` ignored, no-op when nothing is subscribed). FastStream's own create then hits `BUSYGROUP` and it reads with `>`. Works on every FastStream in range (`>=0.6,<0.8`).
- `last_id != ">"` together with a consumer group raises `ValueError` pointing at `group_start`. `last_id` stays available for group-less subscriptions.
- Docs: new "Consuming an Existing Backlog" section; changelog under Added and Changed. The retry subscription keeps starting at `$`.

`group_start` only applies when the group does not exist; a group remembers its position across restarts, which the docs say explicitly.

## Verification (local, live Redis 7 + Redpanda)

| Python | Result |
|---|---|
| 3.12 | 106 passed, 0 skipped |
| 3.10 | 106 passed, 0 skipped; new backlog test 3/3 |

New tests: `test_group_start_zero_delivers_backlog_and_new_entries` (backlog of 2 plus a live entry delivered as `[1, 2, 3]`; restart with the same group delivers only `[4]`), `test_last_id_with_group_is_rejected`; `test_retry_stream_pins_last_id_to_new_entries` switched to `group_start="0"`. All three fail before the change.