### PR TITLE
docs: SECURITY.md supported versions 0.4.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,5 +12,5 @@ https://github.com/eggai-tech/EggAI/security/advisories/new
 
 | Version | Supported |
 | ------- | --------- |
-| 0.3.x   | ✓         |
-| < 0.3.0 | ✗         |
+| 0.4.x   | ✓         |
+| < 0.4.0 | ✗         |


### PR DESCRIPTION
Ahead of the 0.4.0 release (Unreleased carries a breaking change: BaseMessage.data required).