### PR TITLE
fix: restore BaseMessage.data default, validated

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `BaseMessage.data` has its `{}` default back, now declared with
+  `validate_default=True`. 0.4.0 made the field required to stop typed
+  subclasses (`BaseMessage[Order]`) from silently accepting a missing payload;
+  validating the default achieves the same without breaking
+  `BaseMessage(source=..., type=...)` for the untyped base. Typed subclasses
+  still reject a missing or malformed payload with a `ValidationError`.
+
 ## [0.4.0] - 2026-09-07
 
 ### Added

--- a/sdk/eggai/schemas.py
+++ b/sdk/eggai/schemas.py
@@ -67,14 +67,14 @@ class BaseMessage(BaseModel, Generic[TData]):
         default=None,
         description="W3C traceparent for distributed trace context propagation.",
     )
-    # No default here: pydantic does not validate defaults, so a dict default on a
-    # field typed TData would hand every typed subclass a plain `{}` whenever an
-    # envelope omits `data` — the subclass's annotation says Order, the runtime
-    # value is a dict, and the handler crashes on first attribute access. Requiring
-    # the field turns that envelope into a ValidationError, which the transports'
-    # typed subscriptions already treat as "not ours: skip and ack".
+    # validate_default: pydantic does not validate defaults unless asked, so on a
+    # typed subclass (BaseMessage[Order]) a missing `data` used to become a plain
+    # `{}` labelled as Order. With validation the `{}` default fails for typed
+    # subclasses (ValidationError, which typed subscriptions treat as "not ours")
+    # and still works for the untyped base.
     data: TData = Field(
-        ...,
+        default_factory=dict,
+        validate_default=True,
         description="Event payload containing application-specific data.",
     )
 

--- a/sdk/tests/test_schemas.py
+++ b/sdk/tests/test_schemas.py
@@ -36,6 +36,14 @@ def test_typed_subclass_accepts_valid_data():
     assert msg.data.order_id == 7
 
 
+def test_untyped_base_message_defaults_to_empty_dict():
+    # Only typed subclasses reject a missing payload; the generic base keeps
+    # working without one (0.4.0 briefly required it, restored in 0.4.1).
+    msg = BaseMessage(source="t", type="test.event")
+    assert msg.data == {}
+    assert BaseMessage.model_validate({"source": "t", "type": "test.event"}).data == {}
+
+
 def test_message_still_defaults_to_empty_dict():
     # The dict default lives on the concrete Message, where it is honest.
     msg = Message(source="t", type="test.event")


### PR DESCRIPTION
Undoes the breaking part of #259 while keeping its fix.

#259 made `BaseMessage.data` required because pydantic does not validate defaults, so `BaseMessage[Order]` accepted an envelope with no `data` and handed the handler a plain `{}`. Pydantic's `validate_default=True` covers exactly that case: the `{}` default is validated against the bound type, fails for `BaseMessage[Order]` (ValidationError, which typed subscriptions already treat as "not ours") and passes for the untyped base.

| Case | 0.4.0 | this PR |
|---|---|---|
| `BaseMessage(source, type)` no data | ValidationError | accepted, `data == {}` |
| `BaseMessage[Order]` no data | ValidationError | ValidationError |
| `BaseMessage[Order]` wrong shape | ValidationError | ValidationError |

`Message` is unchanged. New test `test_untyped_base_message_defaults_to_empty_dict` fails on main and passes here; the #259 tests for the typed cases still pass.

Verification (local, live Redis + Redpanda, Python 3.12): 109 passed, 0 skipped; mypy clean in the CI configuration; ruff clean.